### PR TITLE
Align Java baseline to 17 across the build

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,10 +19,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.15.0</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.openjdk.jmh</groupId>

--- a/execution-planner/pom.xml
+++ b/execution-planner/pom.xml
@@ -21,8 +21,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.openjdk.jmh</groupId>

--- a/extensions/quarkus/deployment/pom.xml
+++ b/extensions/quarkus/deployment/pom.xml
@@ -57,9 +57,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <release>17</release>
-                </configuration>
                 <executions>
                     <execution>
                         <id>default-compile</id>

--- a/support-projects/parent/pom.xml
+++ b/support-projects/parent/pom.xml
@@ -51,13 +51,10 @@
 
         <!-- Default properties -->
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
+        <!-- kept for formatter-maven-plugin, which reads these directly and falls back to 1.8 if unset -->
         <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
-        <maven.compiler.testTarget>${maven.compiler.target}</maven.compiler.testTarget>
-        <maven.compiler.testSource>${maven.compiler.source}</maven.compiler.testSource>
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
 
         <!-- Cross plugins settings -->
@@ -67,18 +64,9 @@
         <!-- Make the builds reproducible - see https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
         <project.build.outputTimestamp>2024-10-16T11:35:20Z</project.build.outputTimestamp>
 
-        <!--
-            Options to override the compiler arguments directly on the compiler argument line to separate between what
-            the IDE understands as the source level and what the Maven compiler actually use.
-        -->
-        <maven.compiler.argument.target>${maven.compiler.target}</maven.compiler.argument.target>
-        <maven.compiler.argument.source>${maven.compiler.source}</maven.compiler.argument.source>
-        <maven.compiler.argument.testTarget>${maven.compiler.testTarget}</maven.compiler.argument.testTarget>
-        <maven.compiler.argument.testSource>${maven.compiler.testSource}</maven.compiler.argument.testSource>
-
         <!-- maven-enforcer-plugin -->
         <maven.min.version>3.9.6</maven.min.version>
-        <jdk.min.version>${maven.compiler.argument.source}</jdk.min.version>
+        <jdk.min.version>${maven.compiler.release}</jdk.min.version>
         <insecure.repositories>ERROR</insecure.repositories>
 
     </properties>
@@ -197,10 +185,6 @@
                 <configuration>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
-                    <source>${maven.compiler.argument.source}</source>
-                    <target>${maven.compiler.argument.target}</target>
-                    <testSource>${maven.compiler.argument.testSource}</testSource>
-                    <testTarget>${maven.compiler.argument.testTarget}</testTarget>
                     <parameters>true</parameters>
                     <compilerArgs>
                         <arg>-Xlint:unchecked</arg>


### PR DESCRIPTION
## Description
The project settled on Java 17 as its minimum supported version, but the build config didn't consistently reflect that. The shared compiler baseline was still pinned to 11, with a layer of alias properties duplicating that inconsistency into the compiler plugin and the enforcer's minimum JDK check. A handful of modules carried their own local override to 17 that happened to compensate for it, and one of those overrides had already become redundant on its own.

This meant most of the reactor was quietly compiling against Java 11 while a couple of modules were on 17 - and since some of the frameworks this project already depends on (recent Spring Boot and Quarkus releases) require 17, that inconsistency was a real risk for consumers, not just a cosmetic one. On top of that, the build's own JDK version check wasn't actually validating against the right floor, so a build attempted with an older JDK wouldn't necessarily get rejected the way it should.

This brings the whole reactor onto a single, consistently enforced Java 17 baseline: the shared release property is now 17, the minimum JDK check derives directly from that same property instead of a separate alias chain, and the per-module overrides that either did nothing or had become redundant are gone. No module compiles against an older baseline anymore, and there's no leftover configuration that looks like it enforces one version while a different one is actually in effect.

## Type of Change
Please delete options that are not relevant
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues
Fixes #218

## Checklist
- [x] Formatted according to the  [CONTRIBUTING guidelines](https://github.com/carbonintensityio/scheduler/blob/main/CONTRIBUTING.md)
- [x] Follows the [coding guidelines](https://github.com/carbonintensityio/scheduler/blob/main/CONTRIBUTING.md#coding-guidelines)
- [x] Follows the [logging guidelines](https://github.com/carbonintensityio/scheduler/blob/main/CONTRIBUTING.md#logging-guidelines)
- [ ] Tests are added
- [x] Build runs successfully

-------
