### PR TITLE
Add auto-merge for routine Dependabot bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,42 @@
+name: Dependabot auto-merge
+
+# Approved, green dependency bumps used to just sit there until someone remembered to click
+# merge - that's how the queue backed up for months. This closes that gap for the routine case,
+# without removing human review for the two dependencies where a version bump has actually broken
+# us before (#199): Quarkus and Spring Boot version bumps still need an explicit approval and a
+# manual merge, same as before. Everything else - other Maven dependencies, plugins, and GitHub
+# Actions bumps - merges itself once it's approved and CI is green.
+#
+# This only takes effect once "Allow auto-merge" is turned on in the repository settings
+# (Settings > General > Pull Requests) - that's an admin-only toggle this workflow can't set
+# itself. Until then, `gh pr merge --auto` below will fail harmlessly and the PR just waits for a
+# manual merge like before.
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch dependency metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for routine bumps
+        if: |
+          steps.metadata.outputs.update-type != 'version-update:semver-major' &&
+          !contains(steps.metadata.outputs.dependency-names, 'quarkus') &&
+          !contains(steps.metadata.outputs.dependency-names, 'spring.boot') &&
+          !contains(steps.metadata.outputs.dependency-names, 'spring-boot')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
11 approved, green Dependabot PRs have been sitting open for months (some since May) - not because anyone rejected them, but because the person who used to click merge on these routinely moved to a different project, and nothing ever replaced that habit.

This adds a workflow that closes that gap going forward:

- Runs only for `dependabot[bot]` PRs
- Uses `dependabot/fetch-metadata` to read the update type and dependency name
- Enables `--auto` merge (not an immediate merge - GitHub still waits for approval + green checks) for anything that isn't a major bump and isn't a Quarkus or Spring Boot version bump
- Quarkus and Spring Boot stay manual on purpose - #199 is exactly what an unreviewed framework bump can do, and the compatibility matrix that would catch that class of break isn't merged yet

One thing this can't do itself: "Allow auto-merge" needs to be turned on in repo settings (Settings > General > Pull Requests) - that's admin-only. Until someone flips it, this workflow just does nothing and PRs merge manually like before.
