### PR TITLE
Stop requiring GeneratedServiceProviderBuildItem in SchedulerProcessor

### DIFF
--- a/extensions/quarkus/deployment/src/main/java/io/carbonintensity/scheduler/quarkus/deployment/SchedulerProcessor.java
+++ b/extensions/quarkus/deployment/src/main/java/io/carbonintensity/scheduler/quarkus/deployment/SchedulerProcessor.java
@@ -68,7 +68,6 @@ import io.quarkus.deployment.builditem.ConfigDescriptionBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
-import io.quarkus.deployment.builditem.GeneratedServiceProviderBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceDirectoryBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.gizmo2.ClassOutput;
@@ -289,12 +288,11 @@ public class SchedulerProcessor {
             SchedulerRecorder recorder, List<ScheduledBusinessMethodItem> scheduledMethods,
             BuildProducer<GeneratedClassBuildItem> generatedClasses,
             BuildProducer<GeneratedResourceBuildItem> generatedResources,
-            BuildProducer<GeneratedServiceProviderBuildItem> generatedServiceProviders,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
             AnnotationProxyBuildItem annotationProxy) {
 
         List<MutableScheduledMethod> scheduledMetadata = new ArrayList<>();
-        ClassOutput classOutput = getClassOutput(generatedClasses, generatedResources, generatedServiceProviders);
+        ClassOutput classOutput = getClassOutput(generatedClasses, generatedResources);
 
         for (ScheduledBusinessMethodItem scheduledMethod : scheduledMethods) {
             MutableScheduledMethod metadata = new MutableScheduledMethod();
@@ -319,8 +317,7 @@ public class SchedulerProcessor {
     }
 
     private static @NonNull ClassOutput getClassOutput(BuildProducer<GeneratedClassBuildItem> generatedClasses,
-            BuildProducer<GeneratedResourceBuildItem> generatedResources,
-            BuildProducer<GeneratedServiceProviderBuildItem> generatedServiceProviders) {
+            BuildProducer<GeneratedResourceBuildItem> generatedResources) {
         Function<String, String> generatedToBaseNameFun = name -> {
             // org/acme/Foo_ScheduledInvoker_run_0000 -> org.acme.Foo
             int idx = name.indexOf(INVOKER_SUFFIX);
@@ -333,8 +330,14 @@ public class SchedulerProcessor {
             return name;
         };
 
-        return new GeneratedClassGizmo2Adaptor(generatedClasses, generatedResources,
-                generatedServiceProviders, generatedToBaseNameFun);
+        // Deliberately the 3-arg GeneratedClassGizmo2Adaptor constructor (no
+        // BuildProducer<GeneratedServiceProviderBuildItem>): we never write a
+        // META-INF/services/* resource here, so that build item is never actually produced, and
+        // this overload is present unchanged on Quarkus 3.33 LTS through 3.39+. The 4-arg
+        // overload pulls in GeneratedServiceProviderBuildItem, a class that only exists from
+        // Quarkus 3.37 onward - just referencing it in a build step's parameter list makes
+        // ExtensionLoader fail to load this processor on older Quarkus versions.
+        return new GeneratedClassGizmo2Adaptor(generatedClasses, generatedResources, generatedToBaseNameFun);
     }
 
     private String generateInvoker(ScheduledBusinessMethodItem scheduledMethod, ClassOutput classOutput) {


### PR DESCRIPTION
Since #209 (the Gizmo1->Gizmo2 migration that fixed #199), `SchedulerProcessor`'s build step has been asking Quarkus for a `BuildProducer<GeneratedServiceProviderBuildItem>`. Quarkus's `ExtensionLoader` reflects over every build step's parameter types up front, before running any of them, so just having that parameter in the method signature is enough to fail class loading on any Quarkus version older than 3.37 - which is where `GeneratedServiceProviderBuildItem` was introduced. That silently raised this extension's real minimum supported Quarkus version to 3.37, breaking 3.33 LTS and the 3.34-3.36 line, without anyone deciding that on purpose.

Turns out that producer was never actually needed here. `GeneratedClassGizmo2Adaptor` only produces a `GeneratedServiceProviderBuildItem` when it's asked to write a resource under `META-INF/services/`, and this processor never does that - the generated scheduled-method invokers are looked up directly, not through `ServiceLoader`. `GeneratedClassGizmo2Adaptor` also has a 3-argument constructor that simply omits that producer, and that overload is present unchanged all the way from 3.33.3.1 through at least 3.39.1. So the fix is just to stop asking for it and use that overload instead - no version-conditional code, no falling back to Gizmo1.

Verified by building the extension and running it against a real Quarkus app on 3.33.3.1, 3.34.7, 3.35.4, 3.36.3, 3.38.1 and 3.39.1 - all green, including a test that checks the scheduled job is actually registered at runtime, not just that the app boots. Also reproduced the original failure against unmodified `main` on 3.33.3.1 to confirm it's the same bug from the issue, and ran the existing deployment/runtime test suite to make sure nothing else regressed.

Fixes #229
