### PR TITLE
Check the PR author, not the triggering actor, for dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,7 +22,12 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    # Deliberately checking the PR's author, not `github.actor` - a rebase triggered by a human
+    # commenting "@dependabot rebase" resurfaces as a pull_request event whose actor is that
+    # human, not dependabot, even though dependabot did the actual push. `github.actor` reflects
+    # who triggered this run, not who owns the PR - confirmed by testing a real rebase-by-comment
+    # against this exact condition.
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Fetch dependency metadata
         id: metadata


### PR DESCRIPTION
Found while manually clearing the dependabot backlog: rebasing a PR via an `@dependabot rebase` comment resurfaces as a `pull_request` event whose `github.actor` is whoever posted the comment, not dependabot - even though dependabot did the actual push. That meant the auto-merge job (#226) only ever fired on a PR's very first, purely-dependabot-initiated push, and skipped on every rebase after that.

Switched the condition to `github.event.pull_request.user.login == 'dependabot[bot]'`, which checks who actually owns the PR instead of who triggered this specific run.