### PR TITLE
Spread competing @GreenScheduled jobs across multiple green moments

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,27 @@ Refer to the [ShedLock documentation](https://github.com/lukas-krecan/ShedLock/b
 - Instructions for Spring-based application can be found [here](https://github.com/lukas-krecan/ShedLock?tab=readme-ov-file#enable-and-configure-scheduled-locking-spring).
 - For Quarkus-based applications, use ShedLock's [CDI integration](https://github.com/lukas-krecan/ShedLock?tab=readme-ov-file#cdi-integration).
 
+### Scheduling multiple jobs
+Each `@GreenScheduled` job (`Fixed` or `Successive`) is planned independently, based only on its own window,
+duration and `carbonIntensityZone`. By default, if several jobs within the same application instance target
+the same zone and their optimal windows overlap, they may all be scheduled at the exact same, greenest moment
+- there is no coordination between them out of the box.
+
+Set `green-scheduler.max-concurrent-per-slot` to a positive number to limit how many jobs are allowed to start
+at the exact same slot within the same zone. Jobs beyond that limit are automatically spread to the next-best
+slot instead (taking each job's `duration` into account), and so on for further jobs, until a slot is found
+that satisfies the limit.
+
+This is disabled by default (`0`): existing applications are unaffected unless this property is explicitly
+set, since changing when jobs fire is a deliberate scheduling decision, not something that should change
+silently on upgrade.
+
+A job's own configured window always takes priority over this limit: if every slot within the window is
+already at the limit, the job still runs at its greenest available slot in that window rather than not
+running at all (a warning is logged when this happens). This only coordinates jobs known to this application
+instance - it does not coordinate across multiple instances/replicas of the same application; combine it with
+[ShedLock](#concurrent-executions) if you also run multiple instances.
+
 ## Acknowledgements
 The maven project structure and all documentation regarding contribution is adapted from
 what the [Quarkus](https://github.com/quarkusio/quarkus) community has created. Further acknowledgements can be found in the [NOTICE](NOTICE) file

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/SchedulerConfig.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/SchedulerConfig.java
@@ -60,6 +60,14 @@ public class SchedulerConfig {
 
     private int jobExecutors = SchedulerDefaults.DEFAULT_NUMBER_OF_JOB_EXECUTORS;
 
+    /**
+     * Maximum number of jobs allowed to start at the exact same carbon-intensity slot within the same
+     * zone. {@code 0} (the default) disables this: jobs schedule independently and may land on the same
+     * moment. When set to a positive value, jobs beyond this limit for a given zone/slot are spread to
+     * the next-best slot instead, but a job's configured window always takes priority over this limit.
+     */
+    private int maxConcurrentPerSlot = SchedulerDefaults.DEFAULT_MAX_CONCURRENT_PER_SLOT;
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -77,6 +85,17 @@ public class SchedulerConfig {
             throw new IllegalArgumentException("Job executors cannot be less than 1");
         }
         this.jobExecutors = jobExecutors;
+    }
+
+    public int getMaxConcurrentPerSlot() {
+        return maxConcurrentPerSlot;
+    }
+
+    public void setMaxConcurrentPerSlot(int maxConcurrentPerSlot) {
+        if (maxConcurrentPerSlot < 0) {
+            throw new IllegalArgumentException("Max concurrent per slot cannot be less than 0");
+        }
+        this.maxConcurrentPerSlot = maxConcurrentPerSlot;
     }
 
     public Duration getOverdueGracePeriod() {

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/SchedulerDefaults.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/SchedulerDefaults.java
@@ -16,6 +16,10 @@ public final class SchedulerDefaults {
     public static final Duration DEFAULT_DURATION = Duration.ofSeconds(1);
     public static final String DEFAULT_API_URL = "https://api.carbonintensity.io";
     public static final int DEFAULT_NUMBER_OF_JOB_EXECUTORS = 10;
+    /**
+     * Disabled by default: jobs schedule independently and may land on the exact same slot.
+     */
+    public static final int DEFAULT_MAX_CONCURRENT_PER_SLOT = 0;
 
     private SchedulerDefaults() {
     }

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/SimpleScheduler.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/SimpleScheduler.java
@@ -42,6 +42,7 @@ import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensityDataFetch
 import io.carbonintensity.executionplanner.runtime.impl.rest.CarbonIntensityApiType;
 import io.carbonintensity.executionplanner.runtime.impl.rest.CarbonIntensityRestApi;
 import io.carbonintensity.executionplanner.spi.CarbonIntensityPlanner;
+import io.carbonintensity.executionplanner.spi.ConcurrencySlotTracker;
 import io.carbonintensity.executionplanner.spi.PlanningConstraints;
 import io.carbonintensity.scheduler.ConcurrentExecution;
 import io.carbonintensity.scheduler.GreenScheduled;
@@ -114,6 +115,7 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
     private final ConcurrentMap<String, ScheduledTask> scheduledTasks;
     private final boolean enabled;
     private final SchedulerConfig schedulerConfig;
+    private final ConcurrencySlotTracker slotTracker;
     private final JobInstrumenter jobInstrumenter;
     private final List<EventListener> eventListeners;
     private final Events events;
@@ -127,6 +129,7 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         this.schedulerConfig = schedulerConfig;
         this.jobInstrumenter = schedulerConfig.getJobInstrumenter();
         this.eventListeners = new ArrayList<>();
+        this.slotTracker = new ConcurrencySlotTracker();
 
         if (!schedulerConfig.isEnabled()) {
             log.info("Simple scheduler is disabled by config property and will not be started.");
@@ -425,12 +428,14 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
 
         if (constraints instanceof FixedWindowPlanningConstraints) {
             var fixedWindowConstraints = (FixedWindowPlanningConstraints) constraints;
-            CarbonIntensityPlanner<FixedWindowPlanningConstraints> fixedWindowPlanner = new FixedWindowPlanner(dataFetcher);
+            CarbonIntensityPlanner<FixedWindowPlanningConstraints> fixedWindowPlanner = new FixedWindowPlanner(dataFetcher,
+                    slotTracker, schedulerConfig.getMaxConcurrentPerSlot());
             return new FixedWindowTrigger(id, methodDescription, overdueGracePeriod, fixedWindowPlanner,
                     fixedWindowConstraints, clock);
         } else if (constraints instanceof SuccessivePlanningConstraints) {
             var successiveConstraints = (SuccessivePlanningConstraints) constraints;
-            CarbonIntensityPlanner<SuccessivePlanningConstraints> successivePlanner = new SuccessivePlanner(dataFetcher);
+            CarbonIntensityPlanner<SuccessivePlanningConstraints> successivePlanner = new SuccessivePlanner(dataFetcher,
+                    slotTracker, schedulerConfig.getMaxConcurrentPerSlot());
             final var start = ZonedDateTime.now(clock).truncatedTo(ChronoUnit.SECONDS);
             return new SuccessiveTrigger(id, clock, start, methodDescription, overdueGracePeriod, successivePlanner,
                     successiveConstraints);

--- a/docs/adr/0002-spread-concurrent-scheduled-jobs.md
+++ b/docs/adr/0002-spread-concurrent-scheduled-jobs.md
@@ -1,0 +1,118 @@
+# 2. Spreading concurrent scheduled jobs across carbon-intensity slots
+
+## Status
+
+Accepted
+
+## Context
+
+Every `@GreenScheduled` job picks its own greenest moment independently: `SingleJobStrategy.bestTimeslot(ws, we,
+duration, carbonIntensity)` looks only at that one job's window, duration and `carbonIntensityZone`. There is no
+coordination across jobs - `SchedulerContextImpl` holds the full job list for an application but never uses it
+for that purpose, and the existing `ConcurrentExecution` enum only guards re-entrancy of a *single* job's repeated
+runs (and explicitly doesn't work across a cluster; see the "Concurrent executions" page in the docs site, which
+covers that different problem).
+
+The origin was a scaling concern raised by Wilko Zonnenberg: if an application has, say, ten `@GreenScheduled`
+jobs and the greenest moment for all of them happens to be the same instant, they all fire together and can
+overload the machine - even though several of them would have been just as green a few minutes or hours later.
+
+This belongs in `green-scheduler`, not in `carbonintensity-api`: the API is a stateless, job-agnostic
+time-series provider with no concept of a job, its duration, or concurrency between jobs. All "best moment"
+logic already lives here, in the planners.
+
+The design was worked out via a design review with advisor input (issue #234) before implementation (PR #235,
+which resolved #234). This ADR captures the five decisions reached there, checked against what actually shipped.
+
+## Decision
+
+### Scope: JVM-local only
+
+Coordination happens only between `@GreenScheduled` jobs running in the same application instance. Cluster-wide
+coordination between replicas of the *same* job is an explicit non-goal - it's a separate, much larger problem
+(distributed locking / leader election) that would need its own design.
+
+This is reflected directly in the shipped code: `SimpleScheduler` owns a single `ConcurrencySlotTracker` instance
+per `SimpleScheduler` (i.e. per running application instance) and hands it to every `FixedWindowPlanner` and
+`SuccessivePlanner` it creates. Nothing about the tracker is shared or persisted beyond that JVM's process
+lifetime. Users who also need cross-instance coordination are pointed at ShedLock (already used for the
+unrelated re-entrancy problem) rather than at this feature.
+
+### Granularity: per zone, not global per application
+
+Jobs targeting different `CarbonIntensityZone`s have independent optimal moments and must not compete for the
+same slot count just because they happen to run in the same application. `ConcurrencySlotTracker` reflects this
+directly: its bookkeeping (`slotsByZone`, `reservedSlotByZoneAndIdentity`) is keyed first by zone, so two jobs in
+different zones never contend with each other regardless of timing.
+
+Within a zone, only jobs whose candidate windows actually overlap in time end up contending for a slot - this
+falls out naturally from keying reservations by exact instant (`countOthersAt(zone, jobIdentity, slotStart)`),
+rather than needing an explicit "window" concept in the tracker itself. A job whose window never proposes a
+given instant simply never reserves it.
+
+### Default: opt-in, off by default
+
+`maxConcurrentPerSlot` defaults to `0` in `SchedulerConfig`/`SchedulerDefaults`, and both the Quarkus
+(`green-scheduler.max-concurrent-per-slot`) and Spring Boot equivalents carry the same default through. `0`
+means spreading is disabled: existing behavior (jobs may collide on the same moment) is preserved unless a user
+opts in. This is shipped as a **minor** release, not a breaking one - spreading changes *when* a job fires, which
+is scheduling semantics a user has to consent to, unlike an operational safety knob such as `jobExecutors`.
+
+Note that in the shipped code the tracker is always constructed and always passed into every `FixedWindowPlanner`
+and `SuccessivePlanner` (there's no "tracker is null when disabled" branch at the `SimpleScheduler` level); each
+planner instead checks `maxConcurrentPerSlot <= 0` and, when true, calls `strategy.bestTimeslot(...)` exactly as
+before the feature existed, bypassing the tracker entirely. The externally observable behavior is identical to
+"off" either way, but it's worth knowing the off-switch lives in the planners' `getNextExecutionTime`, not in
+whether a tracker exists.
+
+### Configuration shape: one global property
+
+A single property, `maxConcurrentPerSlot`, analogous to `jobExecutors`. It lives once in `core`'s
+`SchedulerConfig`/`SchedulerDefaults` and is surfaced through both the Quarkus `GreenSchedulerProperties`
+(`@ConfigMapping`, `OptionalInt maxConcurrentPerSlot()`) and the Spring Boot `GreenSchedulerProperties`/
+`SchedulerConfigBuilder`, exactly as `jobExecutors` already is. There is no per-job attribute on
+`@GreenScheduled` - every job in an application shares the same limit. A per-job override was explicitly left
+for later, only if concretely needed.
+
+### Overflow behavior: the job's own window always wins
+
+A job's configured window is a hard promise to the user and always takes priority over the concurrency limit. In
+`FixedWindowPlanner.pickTimeslot(...)`, `SingleJobStrategy.rankedTimeslots(...)` returns all candidate slots in
+the window ordered by intensity; the planner walks that list and reserves the first slot where
+`slotTracker.countOthersAt(zone, identity, slot) < maxConcurrentPerSlot`. If none qualify, the job still runs at
+its single greenest slot in the window - the limit is best-effort, not a hard cap - and a `log.warn(...)` records
+that the limit was exceeded for that zone/slot/job.
+
+The original #234 write-up expected this fallback to be needed only in `FixedWindowPlanner`, reasoning that
+`SuccessivePlanner` "has no such conflict since it can simply look further ahead." **The shipped implementation
+diverges here**: `SuccessivePlanner` also has a bounded window for concurrency purposes - `ws`..`we`, computed as
+either `initialStartTime`..`initialStartTime + initialMaximumDelay` (first run) or
+`lastExecutionTime + minimumGap`..`lastExecutionTime + maximumGap` (subsequent runs) - and it cannot look past
+`we` without breaking its own gap contract. `SuccessivePlanner.pickTimeslot(...)` therefore implements the exact
+same ranked-list-then-fallback logic as `FixedWindowPlanner`, including its own `log.warn(...)` ("...to honor its
+gap window"). In practice both planners end up with identical overflow handling; the "always honor the window"
+promise turned out to apply uniformly rather than being specific to `FixedWindowPlanner`.
+
+One further implementation detail not spelled out in #234: the concurrency check and reservation
+(`pickTimeslot`) live inside `FixedWindowPlanner`/`SuccessivePlanner` themselves, not in
+`SimpleScheduler.checkTriggers()` or a separate coordinator class as #234's "suggested implementation shape"
+sketched. The shared state (`ConcurrencySlotTracker`) is still owned and created once by `SimpleScheduler` and
+injected into each planner in `createTrigger(...)`, which achieves the same JVM-wide coordination goal; only the
+call site of the actual pick-a-slot decision differs from what was sketched. `SingleJobStrategy` itself stayed
+stateless and per-job, as intended - it only gained `rankedTimeslots(...)` (with `bestTimeslot(...)` now built on
+top of it) so callers can walk multiple candidates instead of only the single best.
+
+## Consequences
+
+Jobs in the same zone with overlapping windows no longer have to collide on the exact same moment once a user
+opts in, without changing default behavior for anyone who doesn't. The cost is a small amount of shared mutable
+state per application instance (`ConcurrencySlotTracker`) and two planners that now each carry both a stateless
+"pick the best slot" path and a stateful "pick the best non-conflicting slot, falling back to best-effort" path,
+rather than a single code path. The limit is intentionally soft: a job can still exceed `maxConcurrentPerSlot` if
+its window leaves no other option, which is the correct trade-off given decision 3 above (a job's own window is a
+promise, the limit is not), but it means `maxConcurrentPerSlot` alone doesn't guarantee an upper bound on
+simultaneous starts under a tight configuration - only a `log.warn` records when that happens. Whether that
+warrants a metric (beyond the log) is tracked separately, outside this ADR's scope.
+
+Cross-instance coordination (multiple replicas of the same application) and per-job limit overrides remain
+explicitly out of scope, as decided in #234; both would need their own design work if ever needed.

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/fixedwindow/FixedWindowPlanner.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/fixedwindow/FixedWindowPlanner.java
@@ -2,10 +2,17 @@ package io.carbonintensity.executionplanner.planner.fixedwindow;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.carbonintensity.executionplanner.planner.Timeslot;
+import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensity;
 import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensityDataFetcher;
 import io.carbonintensity.executionplanner.runtime.impl.ZonedCarbonIntensityPeriod;
 import io.carbonintensity.executionplanner.spi.CarbonIntensityPlanner;
+import io.carbonintensity.executionplanner.spi.ConcurrencySlotTracker;
 import io.carbonintensity.executionplanner.strategy.SingleJobStrategy;
 
 /**
@@ -20,6 +27,13 @@ import io.carbonintensity.executionplanner.strategy.SingleJobStrategy;
  * for execution based on the constraints provided.
  * </p>
  *
+ * <p>
+ * When a {@link ConcurrencySlotTracker} and a positive {@code maxConcurrentPerSlot} are supplied, jobs
+ * that would otherwise all land on the same slot within the same zone are spread across the next-best
+ * slots instead, up to that limit per slot. The fixed window is always honored: if no slot within it
+ * satisfies the limit, the job still runs at the greenest slot in the window regardless of the limit.
+ * </p>
+ *
  * @see CarbonIntensityPlanner
  * @see FixedWindowPlanningConstraints
  * @see SingleJobStrategy
@@ -28,10 +42,27 @@ import io.carbonintensity.executionplanner.strategy.SingleJobStrategy;
  */
 public class FixedWindowPlanner implements CarbonIntensityPlanner<FixedWindowPlanningConstraints> {
 
+    private static final Logger log = LoggerFactory.getLogger(FixedWindowPlanner.class);
+
     private final CarbonIntensityDataFetcher dataFetcher;
+    private final ConcurrencySlotTracker slotTracker;
+    private final int maxConcurrentPerSlot;
 
     public FixedWindowPlanner(CarbonIntensityDataFetcher dataFetcher) {
+        this(dataFetcher, null, 0);
+    }
+
+    /**
+     * @param slotTracker shared tracker used to spread jobs across multiple green moments when several
+     *        compete for the same slot within the same zone, or {@code null} to disable spreading
+     * @param maxConcurrentPerSlot maximum number of jobs allowed to start at the exact same slot within a
+     *        zone; ignored when {@code slotTracker} is {@code null}. A value {@code <= 0} disables spreading.
+     */
+    public FixedWindowPlanner(CarbonIntensityDataFetcher dataFetcher, ConcurrencySlotTracker slotTracker,
+            int maxConcurrentPerSlot) {
         this.dataFetcher = dataFetcher;
+        this.slotTracker = slotTracker;
+        this.maxConcurrentPerSlot = maxConcurrentPerSlot;
     }
 
     @Override
@@ -50,7 +81,40 @@ public class FixedWindowPlanner implements CarbonIntensityPlanner<FixedWindowPla
         final var carbonIntensity = dataFetcher.fetchCarbonIntensity(period);
 
         final var strategy = new SingleJobStrategy(Duration.ofHours(1));
-        return strategy.bestTimeslot(constraints.getStart(), constraints.getEnd(), constraints.getDuration(),
-                carbonIntensity).start();
+
+        if (slotTracker == null || maxConcurrentPerSlot <= 0) {
+            Timeslot best = strategy.bestTimeslot(constraints.getStart(), constraints.getEnd(), constraints.getDuration(),
+                    carbonIntensity);
+            return best == null ? null : best.start();
+        }
+
+        return pickTimeslot(strategy, constraints, carbonIntensity);
+    }
+
+    private ZonedDateTime pickTimeslot(SingleJobStrategy strategy, FixedWindowPlanningConstraints constraints,
+            CarbonIntensity carbonIntensity) {
+        List<Timeslot> ranked = strategy.rankedTimeslots(constraints.getStart(), constraints.getEnd(),
+                constraints.getDuration(), carbonIntensity);
+        if (ranked.isEmpty()) {
+            return null;
+        }
+
+        String zone = constraints.getCarbonIntensityZone();
+        String identity = constraints.getIdentity();
+        for (Timeslot candidate : ranked) {
+            if (slotTracker.countOthersAt(zone, identity, candidate.start().toInstant()) < maxConcurrentPerSlot) {
+                slotTracker.reserve(zone, identity, candidate.start().toInstant());
+                return candidate.start();
+            }
+        }
+
+        // The fixed window is a hard promise to the user and always wins: if no slot inside it still
+        // satisfies the concurrency limit, run anyway at the greenest slot instead of not running at all.
+        Timeslot best = ranked.get(0);
+        log.warn(
+                "Concurrency limit of {} per slot exceeded for zone {} at {} - scheduling '{}' anyway to honor its fixed window",
+                maxConcurrentPerSlot, zone, best.start(), identity);
+        slotTracker.reserve(zone, identity, best.start().toInstant());
+        return best.start();
     }
 }

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/fixedwindow/FixedWindowPlanner.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/fixedwindow/FixedWindowPlanner.java
@@ -102,8 +102,7 @@ public class FixedWindowPlanner implements CarbonIntensityPlanner<FixedWindowPla
         String zone = constraints.getCarbonIntensityZone();
         String identity = constraints.getIdentity();
         for (Timeslot candidate : ranked) {
-            if (slotTracker.countOthersAt(zone, identity, candidate.start().toInstant()) < maxConcurrentPerSlot) {
-                slotTracker.reserve(zone, identity, candidate.start().toInstant());
+            if (slotTracker.tryReserve(zone, identity, candidate.start().toInstant(), maxConcurrentPerSlot)) {
                 return candidate.start();
             }
         }

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/successive/SuccessivePlanner.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/successive/SuccessivePlanner.java
@@ -110,8 +110,7 @@ public class SuccessivePlanner implements CarbonIntensityPlanner<SuccessivePlann
         String zone = constraints.getCarbonIntensityZone();
         String identity = constraints.getIdentity();
         for (Timeslot candidate : ranked) {
-            if (slotTracker.countOthersAt(zone, identity, candidate.start().toInstant()) < maxConcurrentPerSlot) {
-                slotTracker.reserve(zone, identity, candidate.start().toInstant());
+            if (slotTracker.tryReserve(zone, identity, candidate.start().toInstant(), maxConcurrentPerSlot)) {
                 return candidate.start();
             }
         }

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/successive/SuccessivePlanner.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/successive/SuccessivePlanner.java
@@ -1,11 +1,17 @@
 package io.carbonintensity.executionplanner.planner.successive;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.carbonintensity.executionplanner.planner.Timeslot;
 import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensity;
 import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensityDataFetcher;
 import io.carbonintensity.executionplanner.runtime.impl.ZonedCarbonIntensityPeriod;
 import io.carbonintensity.executionplanner.spi.CarbonIntensityPlanner;
+import io.carbonintensity.executionplanner.spi.ConcurrencySlotTracker;
 import io.carbonintensity.executionplanner.strategy.SingleJobStrategy;
 
 /**
@@ -19,6 +25,13 @@ import io.carbonintensity.executionplanner.strategy.SingleJobStrategy;
  * and uses the {@link SingleJobStrategy} to find the best time slot within the given constraints.
  * </p>
  *
+ * <p>
+ * When a {@link ConcurrencySlotTracker} and a positive {@code maxConcurrentPerSlot} are supplied, jobs
+ * that would otherwise all land on the same slot within the same zone are spread across the next-best
+ * slots instead, up to that limit per slot. The gap window is always honored: if no slot within it
+ * satisfies the limit, the job still runs at the greenest slot in the window regardless of the limit.
+ * </p>
+ *
  * @see CarbonIntensityPlanner
  * @see SuccessivePlanningConstraints
  * @see SingleJobStrategy
@@ -27,10 +40,27 @@ import io.carbonintensity.executionplanner.strategy.SingleJobStrategy;
  */
 public class SuccessivePlanner implements CarbonIntensityPlanner<SuccessivePlanningConstraints> {
 
+    private static final Logger log = LoggerFactory.getLogger(SuccessivePlanner.class);
+
     private final CarbonIntensityDataFetcher dataFetcher;
+    private final ConcurrencySlotTracker slotTracker;
+    private final int maxConcurrentPerSlot;
 
     public SuccessivePlanner(CarbonIntensityDataFetcher dataFetcher) {
+        this(dataFetcher, null, 0);
+    }
+
+    /**
+     * @param slotTracker shared tracker used to spread jobs across multiple green moments when several
+     *        compete for the same slot within the same zone, or {@code null} to disable spreading
+     * @param maxConcurrentPerSlot maximum number of jobs allowed to start at the exact same slot within a
+     *        zone; ignored when {@code slotTracker} is {@code null}. A value {@code <= 0} disables spreading.
+     */
+    public SuccessivePlanner(CarbonIntensityDataFetcher dataFetcher, ConcurrencySlotTracker slotTracker,
+            int maxConcurrentPerSlot) {
         this.dataFetcher = dataFetcher;
+        this.slotTracker = slotTracker;
+        this.maxConcurrentPerSlot = maxConcurrentPerSlot;
     }
 
     @Override
@@ -60,8 +90,40 @@ public class SuccessivePlanner implements CarbonIntensityPlanner<SuccessivePlann
                 .build();
         CarbonIntensity carbonIntensity = dataFetcher.fetchCarbonIntensity(zonedPeriod);
 
-        SingleJobStrategy initialStrategy = new SingleJobStrategy();
-        return initialStrategy.bestTimeslot(ws, we, constraints.getDuration(), carbonIntensity).start();
+        SingleJobStrategy strategy = new SingleJobStrategy();
+
+        if (slotTracker == null || maxConcurrentPerSlot <= 0) {
+            Timeslot best = strategy.bestTimeslot(ws, we, constraints.getDuration(), carbonIntensity);
+            return best == null ? null : best.start();
+        }
+
+        return pickTimeslot(strategy, constraints, ws, we, carbonIntensity);
+    }
+
+    private ZonedDateTime pickTimeslot(SingleJobStrategy strategy, SuccessivePlanningConstraints constraints,
+            ZonedDateTime ws, ZonedDateTime we, CarbonIntensity carbonIntensity) {
+        List<Timeslot> ranked = strategy.rankedTimeslots(ws, we, constraints.getDuration(), carbonIntensity);
+        if (ranked.isEmpty()) {
+            return null;
+        }
+
+        String zone = constraints.getCarbonIntensityZone();
+        String identity = constraints.getIdentity();
+        for (Timeslot candidate : ranked) {
+            if (slotTracker.countOthersAt(zone, identity, candidate.start().toInstant()) < maxConcurrentPerSlot) {
+                slotTracker.reserve(zone, identity, candidate.start().toInstant());
+                return candidate.start();
+            }
+        }
+
+        // The gap window is a hard promise to the user and always wins: if no slot inside it still
+        // satisfies the concurrency limit, run anyway at the greenest slot instead of not running at all.
+        Timeslot best = ranked.get(0);
+        log.warn(
+                "Concurrency limit of {} per slot exceeded for zone {} at {} - scheduling '{}' anyway to honor its gap window",
+                maxConcurrentPerSlot, zone, best.start(), identity);
+        slotTracker.reserve(zone, identity, best.start().toInstant());
+        return best.start();
     }
 
 }

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/spi/ConcurrencySlotTracker.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/spi/ConcurrencySlotTracker.java
@@ -1,0 +1,59 @@
+package io.carbonintensity.executionplanner.spi;
+
+import java.time.Instant;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Tracks, per carbon-intensity zone, which job identities are currently reserved to start at a given
+ * instant. Used by {@link CarbonIntensityPlanner} implementations to spread jobs across multiple green
+ * moments when several of them would otherwise all land on the exact same moment within the same zone.
+ * <p>
+ * A single tracker instance is meant to be shared by all jobs scheduled within one application instance.
+ * It only coordinates jobs known to this JVM - it is not intended to coordinate scheduling across a
+ * cluster of application instances.
+ */
+public class ConcurrencySlotTracker {
+
+    private final ConcurrentMap<String, ConcurrentMap<Instant, Set<String>>> slotsByZone = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, ConcurrentMap<String, Instant>> reservedSlotByZoneAndIdentity = new ConcurrentHashMap<>();
+
+    /**
+     * Reserves the given slot for the given job identity within the given zone, replacing any previous
+     * reservation this identity held in that zone.
+     */
+    public void reserve(String zone, String jobIdentity, Instant slotStart) {
+        ConcurrentMap<String, Instant> reservedByIdentity = reservedSlotByZoneAndIdentity.computeIfAbsent(zone,
+                z -> new ConcurrentHashMap<>());
+        ConcurrentMap<Instant, Set<String>> slots = slotsByZone.computeIfAbsent(zone, z -> new ConcurrentHashMap<>());
+
+        Instant previous = reservedByIdentity.put(jobIdentity, slotStart);
+        if (previous != null && !previous.equals(slotStart)) {
+            Set<String> previousOccupants = slots.get(previous);
+            if (previousOccupants != null) {
+                previousOccupants.remove(jobIdentity);
+                if (previousOccupants.isEmpty()) {
+                    slots.remove(previous, previousOccupants);
+                }
+            }
+        }
+        slots.computeIfAbsent(slotStart, s -> ConcurrentHashMap.newKeySet()).add(jobIdentity);
+    }
+
+    /**
+     * @return the number of job identities, other than {@code jobIdentity} itself, already reserved to
+     *         start at {@code slotStart} within {@code zone}.
+     */
+    public int countOthersAt(String zone, String jobIdentity, Instant slotStart) {
+        ConcurrentMap<Instant, Set<String>> slots = slotsByZone.get(zone);
+        if (slots == null) {
+            return 0;
+        }
+        Set<String> occupants = slots.get(slotStart);
+        if (occupants == null) {
+            return 0;
+        }
+        return occupants.contains(jobIdentity) ? occupants.size() - 1 : occupants.size();
+    }
+}

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/spi/ConcurrencySlotTracker.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/spi/ConcurrencySlotTracker.java
@@ -13,17 +13,64 @@ import java.util.concurrent.ConcurrentMap;
  * A single tracker instance is meant to be shared by all jobs scheduled within one application instance.
  * It only coordinates jobs known to this JVM - it is not intended to coordinate scheduling across a
  * cluster of application instances.
+ * <p>
+ * All three public methods are serialized per zone (via an internal per-zone lock), so concurrent callers
+ * targeting the same zone never observe a torn intermediate state and {@link #tryReserve} is a genuine
+ * check-and-reserve compound operation, not a check-then-act race. Two different zones never contend on
+ * the same lock, preserving the existing zone-isolation guarantee.
  */
 public class ConcurrencySlotTracker {
 
     private final ConcurrentMap<String, ConcurrentMap<Instant, Set<String>>> slotsByZone = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, ConcurrentMap<String, Instant>> reservedSlotByZoneAndIdentity = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Object> zoneLocks = new ConcurrentHashMap<>();
 
     /**
      * Reserves the given slot for the given job identity within the given zone, replacing any previous
-     * reservation this identity held in that zone.
+     * reservation this identity held in that zone, regardless of how many other identities already
+     * occupy that slot. Used for the "the job's own window always wins" fallback - prefer
+     * {@link #tryReserve} when a concurrency limit should actually be enforced.
      */
     public void reserve(String zone, String jobIdentity, Instant slotStart) {
+        synchronized (lockFor(zone)) {
+            reserveLocked(zone, jobIdentity, slotStart);
+        }
+    }
+
+    /**
+     * @return the number of job identities, other than {@code jobIdentity} itself, already reserved to
+     *         start at {@code slotStart} within {@code zone}.
+     */
+    public int countOthersAt(String zone, String jobIdentity, Instant slotStart) {
+        synchronized (lockFor(zone)) {
+            return countOthersAtLocked(zone, jobIdentity, slotStart);
+        }
+    }
+
+    /**
+     * Atomically checks whether fewer than {@code maxConcurrentPerSlot} other identities already occupy
+     * {@code slotStart} within {@code zone}, and if so, reserves it for {@code jobIdentity} - all under
+     * the same per-zone lock, so no other {@code tryReserve}/{@code reserve}/{@code countOthersAt} call
+     * for the same zone can interleave between the check and the reservation.
+     *
+     * @return {@code true} if the slot was reserved; {@code false} if the limit was already reached, in
+     *         which case no state is changed.
+     */
+    public boolean tryReserve(String zone, String jobIdentity, Instant slotStart, int maxConcurrentPerSlot) {
+        synchronized (lockFor(zone)) {
+            if (countOthersAtLocked(zone, jobIdentity, slotStart) >= maxConcurrentPerSlot) {
+                return false;
+            }
+            reserveLocked(zone, jobIdentity, slotStart);
+            return true;
+        }
+    }
+
+    private Object lockFor(String zone) {
+        return zoneLocks.computeIfAbsent(zone, z -> new Object());
+    }
+
+    private void reserveLocked(String zone, String jobIdentity, Instant slotStart) {
         ConcurrentMap<String, Instant> reservedByIdentity = reservedSlotByZoneAndIdentity.computeIfAbsent(zone,
                 z -> new ConcurrentHashMap<>());
         ConcurrentMap<Instant, Set<String>> slots = slotsByZone.computeIfAbsent(zone, z -> new ConcurrentHashMap<>());
@@ -41,11 +88,7 @@ public class ConcurrencySlotTracker {
         slots.computeIfAbsent(slotStart, s -> ConcurrentHashMap.newKeySet()).add(jobIdentity);
     }
 
-    /**
-     * @return the number of job identities, other than {@code jobIdentity} itself, already reserved to
-     *         start at {@code slotStart} within {@code zone}.
-     */
-    public int countOthersAt(String zone, String jobIdentity, Instant slotStart) {
+    private int countOthersAtLocked(String zone, String jobIdentity, Instant slotStart) {
         ConcurrentMap<Instant, Set<String>> slots = slotsByZone.get(zone);
         if (slots == null) {
             return 0;

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/strategy/PlanningStrategy.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/strategy/PlanningStrategy.java
@@ -2,10 +2,24 @@ package io.carbonintensity.executionplanner.strategy;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.List;
 
 import io.carbonintensity.executionplanner.planner.Timeslot;
 import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensity;
 
 public interface PlanningStrategy {
     Timeslot bestTimeslot(ZonedDateTime ws, ZonedDateTime we, Duration duration, CarbonIntensity carbonIntensity);
+
+    /**
+     * Returns all viable timeslots in the given window, ranked from lowest (best) to highest carbon intensity.
+     * Used to find an alternative slot when the single best slot is already claimed by another job.
+     * <p>
+     * The default implementation only returns the single best slot computed by
+     * {@link #bestTimeslot(ZonedDateTime, ZonedDateTime, Duration, CarbonIntensity)}.
+     */
+    default List<Timeslot> rankedTimeslots(ZonedDateTime ws, ZonedDateTime we, Duration duration,
+            CarbonIntensity carbonIntensity) {
+        Timeslot best = bestTimeslot(ws, we, duration, carbonIntensity);
+        return best == null ? List.of() : List.of(best);
+    }
 }

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/strategy/SingleJobStrategy.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/strategy/SingleJobStrategy.java
@@ -4,6 +4,8 @@ import static io.carbonintensity.executionplanner.planner.Timeslot.getTimeslots;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -35,25 +37,26 @@ public class SingleJobStrategy implements PlanningStrategy {
 
     @Override
     public Timeslot bestTimeslot(ZonedDateTime ws, ZonedDateTime we, Duration duration, CarbonIntensity carbonIntensity) {
-
-        // create timeslots and calculate carbon intensity
-        List<Timeslot> timeslots = getTimeslots(ws, we, duration, resolution, carbonIntensity);
-
-        if (timeslots.isEmpty()) {
+        List<Timeslot> ranked = rankedTimeslots(ws, we, duration, carbonIntensity);
+        if (ranked.isEmpty()) {
             log.warn("No timeslots found!  {}", carbonIntensity.getData().size());
             return null;
         }
 
-        Timeslot best = null;
-        for (Timeslot t : timeslots) {
-            if (best == null || t.carbonIntensity().compareTo(best.carbonIntensity()) < 0) {
-                best = t;
-            }
-        }
-
+        Timeslot best = ranked.get(0);
         log.debug("Found best timeslot of {} job between {} - {} at {} (CI: {})", duration, ws, we, best.start(),
                 best.carbonIntensity());
         return best;
+    }
+
+    @Override
+    public List<Timeslot> rankedTimeslots(ZonedDateTime ws, ZonedDateTime we, Duration duration,
+            CarbonIntensity carbonIntensity) {
+        // create timeslots and calculate carbon intensity
+        List<Timeslot> timeslots = new ArrayList<>(getTimeslots(ws, we, duration, resolution, carbonIntensity));
+        // stable sort: on equal carbon intensity, the chronologically first slot stays first
+        timeslots.sort(Comparator.comparing(Timeslot::carbonIntensity));
+        return timeslots;
     }
 
 }

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/fixedwindow/TestFixedWindowPlanner.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/fixedwindow/TestFixedWindowPlanner.java
@@ -22,6 +22,8 @@ import com.cronutils.parser.CronParser;
 
 import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensityDataFetcher;
 import io.carbonintensity.executionplanner.runtime.impl.rest.CarbonIntensityJsonParser;
+import io.carbonintensity.executionplanner.spi.CarbonIntensityPlanner;
+import io.carbonintensity.executionplanner.spi.ConcurrencySlotTracker;
 
 @ExtendWith(MockitoExtension.class)
 class TestFixedWindowPlanner {
@@ -33,6 +35,73 @@ class TestFixedWindowPlanner {
     public void setup() {
         carbonIntensityDataFetcher = mock(CarbonIntensityDataFetcher.class);
         defaultCarbonIntensityScheduler = new FixedWindowPlanner(carbonIntensityDataFetcher);
+    }
+
+    private static FixedWindowPlanningConstraints constraintsFor(String identity, ZonedDateTime start, ZonedDateTime end) {
+        CronParser cronParser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
+        Cron cron = cronParser.parse(String.format("%d %d %d * * ?", start.getSecond(), start.getMinute(), start.getHour()));
+        Cron cronFallback = cronParser.parse("0 0 12 * * ?");
+
+        return DefaultFixedWindowPlanningConstraints.builder()
+                .withIdentity(identity)
+                .withDuration(Duration.ofMinutes(30))
+                .withCarbonIntensityZone("NL")
+                .withCronExpression(cron)
+                .withStartAndEnd(start, end)
+                .withFallbackCronExpression(cronFallback)
+                .withTimeZoneId(ZoneId.of("UTC"))
+                .build();
+    }
+
+    @Test
+    void whenTwoJobsCompeteForTheSameSlot_thenTheSecondJobIsSpreadToTheNextBestSlot() {
+        CarbonIntensityDataFetcher sharedFetcher = mock(CarbonIntensityDataFetcher.class);
+        CarbonIntensityJsonParser parser = new CarbonIntensityJsonParser();
+        var carbonIntensity = parser.parse(ClassLoader.getSystemResourceAsStream("day-ahead-20240824-Z.json"));
+        when(sharedFetcher.fetchCarbonIntensity(any())).thenReturn(carbonIntensity);
+
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+        CarbonIntensityPlanner<FixedWindowPlanningConstraints> plannerA = new FixedWindowPlanner(sharedFetcher, tracker, 1);
+        CarbonIntensityPlanner<FixedWindowPlanningConstraints> plannerB = new FixedWindowPlanner(sharedFetcher, tracker, 1);
+
+        ZonedDateTime ws = ZonedDateTime.parse("2024-08-27T00:00:00Z");
+        ZonedDateTime we = ws.plusHours(6);
+        var constraintsA = constraintsFor("job-a", ws, we);
+        var constraintsB = constraintsFor("job-b", ws, we);
+
+        ZonedDateTime timeA = plannerA.getNextExecutionTime(constraintsA);
+        ZonedDateTime timeB = plannerB.getNextExecutionTime(constraintsB);
+
+        assertThat(timeA).isNotNull();
+        assertThat(timeB).isNotNull();
+        assertThat(timeB).isNotEqualTo(timeA);
+    }
+
+    @Test
+    void whenNoSlotSatisfiesTheLimit_thenTheWindowStillWinsAndJobRunsAnyway() {
+        CarbonIntensityDataFetcher sharedFetcher = mock(CarbonIntensityDataFetcher.class);
+        CarbonIntensityJsonParser parser = new CarbonIntensityJsonParser();
+        var carbonIntensity = parser.parse(ClassLoader.getSystemResourceAsStream("day-ahead-20240824-Z.json"));
+        when(sharedFetcher.fetchCarbonIntensity(any())).thenReturn(carbonIntensity);
+
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+        // window only wide enough for a single 30-minute slot, so no alternative slot can ever exist
+        ZonedDateTime ws = ZonedDateTime.parse("2024-08-27T00:00:00Z");
+        ZonedDateTime we = ws.plusMinutes(30);
+        int maxConcurrentPerSlot = 1;
+
+        CarbonIntensityPlanner<FixedWindowPlanningConstraints> plannerA = new FixedWindowPlanner(sharedFetcher, tracker,
+                maxConcurrentPerSlot);
+        CarbonIntensityPlanner<FixedWindowPlanningConstraints> plannerB = new FixedWindowPlanner(sharedFetcher, tracker,
+                maxConcurrentPerSlot);
+
+        ZonedDateTime timeA = plannerA.getNextExecutionTime(constraintsFor("job-a", ws, we));
+        ZonedDateTime timeB = plannerB.getNextExecutionTime(constraintsFor("job-b", ws, we));
+
+        assertThat(timeA).isNotNull();
+        assertThat(timeB).isNotNull();
+        // no room to spread within this window: both jobs still run, at the same greenest slot
+        assertThat(timeB).isEqualTo(timeA);
     }
 
     @Test

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/fixedwindow/TestFixedWindowPlanner.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/fixedwindow/TestFixedWindowPlanner.java
@@ -42,11 +42,21 @@ class TestFixedWindowPlanner {
     }
 
     private static FixedWindowPlanningConstraints constraintsFor(String identity, ZonedDateTime start, ZonedDateTime end) {
-        return constraintsFor(identity, start, end, Duration.ofMinutes(30));
+        return constraintsFor(identity, "NL", start, end, Duration.ofMinutes(30));
     }
 
     private static FixedWindowPlanningConstraints constraintsFor(String identity, ZonedDateTime start, ZonedDateTime end,
             Duration duration) {
+        return constraintsFor(identity, "NL", start, end, duration);
+    }
+
+    private static FixedWindowPlanningConstraints constraintsFor(String identity, String zone, ZonedDateTime start,
+            ZonedDateTime end) {
+        return constraintsFor(identity, zone, start, end, Duration.ofMinutes(30));
+    }
+
+    private static FixedWindowPlanningConstraints constraintsFor(String identity, String zone, ZonedDateTime start,
+            ZonedDateTime end, Duration duration) {
         CronParser cronParser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
         Cron cron = cronParser.parse(String.format("%d %d %d * * ?", start.getSecond(), start.getMinute(), start.getHour()));
         Cron cronFallback = cronParser.parse("0 0 12 * * ?");
@@ -54,7 +64,7 @@ class TestFixedWindowPlanner {
         return DefaultFixedWindowPlanningConstraints.builder()
                 .withIdentity(identity)
                 .withDuration(duration)
-                .withCarbonIntensityZone("NL")
+                .withCarbonIntensityZone(zone)
                 .withCronExpression(cron)
                 .withStartAndEnd(start, end)
                 .withFallbackCronExpression(cronFallback)
@@ -84,6 +94,34 @@ class TestFixedWindowPlanner {
         assertThat(timeA).isNotNull();
         assertThat(timeB).isNotNull();
         assertThat(timeB).isNotEqualTo(timeA);
+    }
+
+    @Test
+    void whenTwoJobsInDifferentZonesCompeteForTheSameSlot_thenNeitherIsSpread() {
+        CarbonIntensityDataFetcher sharedFetcher = mock(CarbonIntensityDataFetcher.class);
+        CarbonIntensityJsonParser parser = new CarbonIntensityJsonParser();
+        var carbonIntensity = parser.parse(ClassLoader.getSystemResourceAsStream("day-ahead-20240824-Z.json"));
+        // Same fixture regardless of zone is fine here: what matters is that both jobs independently
+        // resolve to the same greenest instant, and neither gets bumped because of the other's zone.
+        when(sharedFetcher.fetchCarbonIntensity(any())).thenReturn(carbonIntensity);
+
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+        CarbonIntensityPlanner<FixedWindowPlanningConstraints> plannerA = new FixedWindowPlanner(sharedFetcher, tracker, 1);
+        CarbonIntensityPlanner<FixedWindowPlanningConstraints> plannerB = new FixedWindowPlanner(sharedFetcher, tracker, 1);
+
+        ZonedDateTime ws = ZonedDateTime.parse("2024-08-27T00:00:00Z");
+        ZonedDateTime we = ws.plusHours(6);
+        var constraintsA = constraintsFor("job-a", "NL", ws, we);
+        var constraintsB = constraintsFor("job-b", "DE", ws, we);
+
+        ZonedDateTime timeA = plannerA.getNextExecutionTime(constraintsA);
+        ZonedDateTime timeB = plannerB.getNextExecutionTime(constraintsB);
+
+        assertThat(timeA).isNotNull();
+        assertThat(timeB).isNotNull();
+        // Different zones never compete for the same slot count: job-b lands on the exact same
+        // instant as job-a instead of being spread to the next-best slot.
+        assertThat(timeB).isEqualTo(timeA);
     }
 
     @Test

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/fixedwindow/TestFixedWindowPlanner.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/fixedwindow/TestFixedWindowPlanner.java
@@ -5,10 +5,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.math.BigDecimal;
 import java.time.DayOfWeek;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,6 +23,7 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
 
+import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensity;
 import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensityDataFetcher;
 import io.carbonintensity.executionplanner.runtime.impl.rest.CarbonIntensityJsonParser;
 import io.carbonintensity.executionplanner.spi.CarbonIntensityPlanner;
@@ -38,13 +42,18 @@ class TestFixedWindowPlanner {
     }
 
     private static FixedWindowPlanningConstraints constraintsFor(String identity, ZonedDateTime start, ZonedDateTime end) {
+        return constraintsFor(identity, start, end, Duration.ofMinutes(30));
+    }
+
+    private static FixedWindowPlanningConstraints constraintsFor(String identity, ZonedDateTime start, ZonedDateTime end,
+            Duration duration) {
         CronParser cronParser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
         Cron cron = cronParser.parse(String.format("%d %d %d * * ?", start.getSecond(), start.getMinute(), start.getHour()));
         Cron cronFallback = cronParser.parse("0 0 12 * * ?");
 
         return DefaultFixedWindowPlanningConstraints.builder()
                 .withIdentity(identity)
-                .withDuration(Duration.ofMinutes(30))
+                .withDuration(duration)
                 .withCarbonIntensityZone("NL")
                 .withCronExpression(cron)
                 .withStartAndEnd(start, end)
@@ -102,6 +111,50 @@ class TestFixedWindowPlanner {
         assertThat(timeB).isNotNull();
         // no room to spread within this window: both jobs still run, at the same greenest slot
         assertThat(timeB).isEqualTo(timeA);
+    }
+
+    /**
+     * When several candidate slots tie on carbon intensity, {@code SingleJobStrategy#rankedTimeslots}
+     * breaks the tie by chronological order (see {@code TestSingleJobStrategy}). This pins that the same
+     * deterministic order is what spreading walks through here: competing jobs land on the tied slots in
+     * chronological order, not in some incidental order.
+     */
+    @Test
+    void whenThreeJobsCompeteForTiedSlots_thenTheyAreSpreadInChronologicalOrder() {
+        CarbonIntensityDataFetcher sharedFetcher = mock(CarbonIntensityDataFetcher.class);
+
+        // hourly data: 01:00, 02:00 and 03:00 all tie at 50, so with a 1-hour job duration those three
+        // timeslots are the tied candidates; 00:00 (100) and 04:00 (200) are strictly worse.
+        CarbonIntensity carbonIntensity = new CarbonIntensity();
+        carbonIntensity.setZone("NL");
+        carbonIntensity.setResolution(Duration.ofHours(1));
+        carbonIntensity.setStart(Instant.parse("2024-01-01T00:00:00Z"));
+        carbonIntensity.setEnd(Instant.parse("2024-01-01T05:00:00Z"));
+        carbonIntensity.setData(List.of(
+                new BigDecimal("100"),
+                new BigDecimal("50"),
+                new BigDecimal("50"),
+                new BigDecimal("50"),
+                new BigDecimal("200")));
+        when(sharedFetcher.fetchCarbonIntensity(any())).thenReturn(carbonIntensity);
+
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+        CarbonIntensityPlanner<FixedWindowPlanningConstraints> plannerA = new FixedWindowPlanner(sharedFetcher, tracker, 1);
+        CarbonIntensityPlanner<FixedWindowPlanningConstraints> plannerB = new FixedWindowPlanner(sharedFetcher, tracker, 1);
+        CarbonIntensityPlanner<FixedWindowPlanningConstraints> plannerC = new FixedWindowPlanner(sharedFetcher, tracker, 1);
+
+        ZonedDateTime ws = ZonedDateTime.parse("2024-01-01T00:00:00Z");
+        ZonedDateTime we = ws.plusHours(4);
+        Duration duration = Duration.ofHours(1);
+
+        ZonedDateTime timeA = plannerA.getNextExecutionTime(constraintsFor("job-a", ws, we, duration));
+        ZonedDateTime timeB = plannerB.getNextExecutionTime(constraintsFor("job-b", ws, we, duration));
+        ZonedDateTime timeC = plannerC.getNextExecutionTime(constraintsFor("job-c", ws, we, duration));
+
+        // the three tied (CI 50) slots are claimed in chronological order: 01:00, then 02:00, then 03:00
+        assertThat(timeA).isEqualTo(ws.plusHours(1));
+        assertThat(timeB).isEqualTo(ws.plusHours(2));
+        assertThat(timeC).isEqualTo(ws.plusHours(3));
     }
 
     @Test

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/successive/TestSuccessivePlanner.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/successive/TestSuccessivePlanner.java
@@ -15,6 +15,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensityDataFetcher;
 import io.carbonintensity.executionplanner.runtime.impl.rest.CarbonIntensityJsonParser;
+import io.carbonintensity.executionplanner.spi.CarbonIntensityPlanner;
+import io.carbonintensity.executionplanner.spi.ConcurrencySlotTracker;
 
 @ExtendWith(MockitoExtension.class)
 class TestSuccessivePlanner {
@@ -26,6 +28,18 @@ class TestSuccessivePlanner {
     public void setup() {
         carbonIntensityDataFetcher = mock(CarbonIntensityDataFetcher.class);
         defaultCarbonIntensityScheduler = new SuccessivePlanner(carbonIntensityDataFetcher);
+    }
+
+    private static SuccessivePlanningConstraints constraintsFor(String identity, ZonedDateTime lastExecutionTime,
+            Duration minimumGap, Duration maximumGap) {
+        return DefaultSuccessivePlanningConstraints.builder()
+                .withIdentity(identity)
+                .withLastExecutionTime(lastExecutionTime)
+                .withMinimumGap(minimumGap)
+                .withMaximumGap(maximumGap)
+                .withDuration(Duration.ofMinutes(30))
+                .withCarbonIntensityZone("NL")
+                .build();
     }
 
     @Test
@@ -82,5 +96,69 @@ class TestSuccessivePlanner {
         // note: we allow the execution on the exact minGap, so should not be before (but equal or after)
         assertThat(nextExecutionTime.isBefore(lastExecutionTime.plus(minGap))).isFalse();
         assertThat(nextExecutionTime.isAfter(lastExecutionTime.plus(maxGap))).isFalse();
+    }
+
+    @Test
+    void whenTwoJobsCompeteForTheSameSlot_thenTheSecondJobIsSpreadToTheNextBestSlot() {
+        CarbonIntensityDataFetcher sharedFetcher = mock(CarbonIntensityDataFetcher.class);
+        CarbonIntensityJsonParser parser = new CarbonIntensityJsonParser();
+        var carbonIntensity = parser.parse(ClassLoader.getSystemResourceAsStream("day-ahead-20240824-Z.json"));
+        when(sharedFetcher.fetchCarbonIntensity(any())).thenReturn(carbonIntensity);
+
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+        CarbonIntensityPlanner<SuccessivePlanningConstraints> plannerA = new SuccessivePlanner(sharedFetcher, tracker, 1);
+        CarbonIntensityPlanner<SuccessivePlanningConstraints> plannerB = new SuccessivePlanner(sharedFetcher, tracker, 1);
+
+        ZonedDateTime lastExecutionTime = ZonedDateTime.parse("2024-08-27T00:00:00Z");
+        Duration minGap = Duration.ZERO;
+        Duration maxGap = Duration.ofHours(6);
+
+        ZonedDateTime timeA = plannerA.getNextExecutionTime(constraintsFor("job-a", lastExecutionTime, minGap, maxGap));
+        ZonedDateTime timeB = plannerB.getNextExecutionTime(constraintsFor("job-b", lastExecutionTime, minGap, maxGap));
+
+        assertThat(timeA).isNotNull();
+        assertThat(timeB).isNotNull();
+        assertThat(timeB).isNotEqualTo(timeA);
+    }
+
+    /**
+     * #234's design decision 5 claims that, unlike {@code FixedWindowPlanner}, "{@code SuccessivePlanner} has no
+     * such conflict since it can simply look further ahead" when no slot within the gap window satisfies the
+     * concurrency limit. That is not what the current implementation does: {@code SuccessivePlanner.pickTimeslot}
+     * ranks candidates via {@code strategy.rankedTimeslots(ws, we, ...)}, strictly bounded by the gap window
+     * {@code [ws, we]} (up to the maximum gap), exactly like {@code FixedWindowPlanner} is bounded by its fixed
+     * window. It never considers slots beyond {@code we}, so when the gap window is too narrow to offer an
+     * alternative slot, it falls back to the exact same "violate the limit, run at the greenest slot anyway"
+     * behavior as {@code FixedWindowPlanner} - it does not "look further ahead". This test documents that the two
+     * planners behave identically in this edge case, contradicting the "no such conflict" claim in #234.
+     */
+    @Test
+    void whenNoSlotSatisfiesTheLimit_thenTheGapWindowStillWinsAndJobRunsAnyway() {
+        CarbonIntensityDataFetcher sharedFetcher = mock(CarbonIntensityDataFetcher.class);
+        CarbonIntensityJsonParser parser = new CarbonIntensityJsonParser();
+        var carbonIntensity = parser.parse(ClassLoader.getSystemResourceAsStream("day-ahead-20240824-Z.json"));
+        when(sharedFetcher.fetchCarbonIntensity(any())).thenReturn(carbonIntensity);
+
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+        // minGap == maxGap collapses the gap window to a single instant, so exactly one candidate slot
+        // exists (see Timeslot.getTimeslots: candidates are generated for every resolution step in
+        // [ws, we], inclusive of we) - no alternative slot can ever exist
+        ZonedDateTime lastExecutionTime = ZonedDateTime.parse("2024-08-27T00:00:00Z");
+        Duration minGap = Duration.ofMinutes(30);
+        Duration maxGap = Duration.ofMinutes(30);
+        int maxConcurrentPerSlot = 1;
+
+        CarbonIntensityPlanner<SuccessivePlanningConstraints> plannerA = new SuccessivePlanner(sharedFetcher, tracker,
+                maxConcurrentPerSlot);
+        CarbonIntensityPlanner<SuccessivePlanningConstraints> plannerB = new SuccessivePlanner(sharedFetcher, tracker,
+                maxConcurrentPerSlot);
+
+        ZonedDateTime timeA = plannerA.getNextExecutionTime(constraintsFor("job-a", lastExecutionTime, minGap, maxGap));
+        ZonedDateTime timeB = plannerB.getNextExecutionTime(constraintsFor("job-b", lastExecutionTime, minGap, maxGap));
+
+        assertThat(timeA).isNotNull();
+        assertThat(timeB).isNotNull();
+        // no room to spread within this gap window: both jobs still run, at the same greenest slot
+        assertThat(timeB).isEqualTo(timeA);
     }
 }

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/spi/TestConcurrencySlotTracker.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/spi/TestConcurrencySlotTracker.java
@@ -3,6 +3,15 @@ package io.carbonintensity.executionplanner.spi;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
 
@@ -44,9 +53,64 @@ class TestConcurrencySlotTracker {
     }
 
     @Test
+    void twoZonesCanIndependentlyReserveTheExactSameInstant() {
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+
+        // Two jobs in different zones both want the exact same instant. Neither should see the
+        // other's reservation: coordination is per zone, never global.
+        tracker.reserve(ZONE_A, "job-a1", SLOT);
+        tracker.reserve(ZONE_B, "job-b1", SLOT);
+
+        // Each was the first (and only) reservation in its own zone, so each sees zero competitors
+        // at that instant - i.e. neither would be bumped to a later slot.
+        assertThat(tracker.countOthersAt(ZONE_A, "job-a1", SLOT)).isZero();
+        assertThat(tracker.countOthersAt(ZONE_B, "job-b1", SLOT)).isZero();
+
+        // A second job arriving in either zone only competes with reservations in that same zone.
+        assertThat(tracker.countOthersAt(ZONE_A, "job-a2", SLOT)).isEqualTo(1);
+        assertThat(tracker.countOthersAt(ZONE_B, "job-b2", SLOT)).isEqualTo(1);
+    }
+
+    @Test
     void countOthersAtIsZeroForAnUnreservedSlot() {
         ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
 
         assertThat(tracker.countOthersAt(ZONE_A, "job-1", SLOT)).isZero();
+    }
+
+    @Test
+    void whenManyThreadsRaceForTheSameSlot_thenExactlyTheLimitSucceeds() throws Exception {
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+        int threadCount = 20;
+        int maxConcurrentPerSlot = 3;
+
+        // All threads call tryReserve for the same zone/slot at (as close to) the exact same moment,
+        // via a barrier - this is the scenario countOthersAt-then-reserve as two separate calls would
+        // race on: every thread could observe "under the limit" before any of them reserves.
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        try {
+            List<Callable<Boolean>> racers = IntStream.range(0, threadCount)
+                    .<Callable<Boolean>> mapToObj(i -> () -> {
+                        barrier.await();
+                        return tracker.tryReserve(ZONE_A, "job-" + i, SLOT, maxConcurrentPerSlot);
+                    })
+                    .collect(Collectors.toList());
+
+            List<Future<Boolean>> results = executor.invokeAll(racers);
+            long successes = results.stream().map(f -> {
+                try {
+                    return f.get();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }).filter(Boolean::booleanValue).count();
+
+            assertThat(successes).isEqualTo(maxConcurrentPerSlot);
+            assertThat(tracker.countOthersAt(ZONE_A, "some-other-job", SLOT)).isEqualTo(maxConcurrentPerSlot);
+        } finally {
+            executor.shutdown();
+            executor.awaitTermination(5, TimeUnit.SECONDS);
+        }
     }
 }

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/spi/TestConcurrencySlotTracker.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/spi/TestConcurrencySlotTracker.java
@@ -1,0 +1,52 @@
+package io.carbonintensity.executionplanner.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+class TestConcurrencySlotTracker {
+
+    private static final String ZONE_A = "NL";
+    private static final String ZONE_B = "DE";
+    private static final Instant SLOT = Instant.parse("2024-08-27T12:00:00Z");
+    private static final Instant OTHER_SLOT = Instant.parse("2024-08-27T13:00:00Z");
+
+    @Test
+    void countOthersAtExcludesTheJobsOwnReservation() {
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+
+        tracker.reserve(ZONE_A, "job-1", SLOT);
+
+        assertThat(tracker.countOthersAt(ZONE_A, "job-1", SLOT)).isZero();
+        assertThat(tracker.countOthersAt(ZONE_A, "job-2", SLOT)).isEqualTo(1);
+    }
+
+    @Test
+    void reservingANewSlotReleasesThePreviousOne() {
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+
+        tracker.reserve(ZONE_A, "job-1", SLOT);
+        tracker.reserve(ZONE_A, "job-1", OTHER_SLOT);
+
+        assertThat(tracker.countOthersAt(ZONE_A, "job-2", SLOT)).isZero();
+        assertThat(tracker.countOthersAt(ZONE_A, "job-2", OTHER_SLOT)).isEqualTo(1);
+    }
+
+    @Test
+    void reservationsAreScopedPerZone() {
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+
+        tracker.reserve(ZONE_A, "job-1", SLOT);
+
+        assertThat(tracker.countOthersAt(ZONE_B, "job-2", SLOT)).isZero();
+    }
+
+    @Test
+    void countOthersAtIsZeroForAnUnreservedSlot() {
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+
+        assertThat(tracker.countOthersAt(ZONE_A, "job-1", SLOT)).isZero();
+    }
+}

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/strategy/TestSingleJobStrategy.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/strategy/TestSingleJobStrategy.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -49,6 +50,47 @@ class TestSingleJobStrategy {
             assertThat(ranked.get(i - 1).carbonIntensity()).isLessThanOrEqualTo(ranked.get(i).carbonIntensity());
         }
         assertThat(ranked.get(0)).usingRecursiveComparison().isEqualTo(strategy.bestTimeslot(ws, we, d, carbonIntensity));
+    }
+
+    /**
+     * {@link SingleJobStrategy#rankedTimeslots} sorts with {@link java.util.List#sort}, which is a stable
+     * sort. On a tie in carbon intensity, this pins the deliberate (not accidental) tie-break: the
+     * chronologically earliest tied slot stays ranked first, then the next earliest, and so on - because
+     * {@link io.carbonintensity.executionplanner.planner.Timeslot#getTimeslots} generates candidate slots
+     * in chronological order in the first place, and a stable sort never reorders equal elements.
+     */
+    @Test
+    void testRankedTimeslotsBreaksTiesByChronologicalOrder() {
+        // hourly data, resolution matches the 1-hour job duration and slot-generation resolution below,
+        // so each generated timeslot lines up exactly with one data point: 100, 50, 50, 50, 200
+        CarbonIntensity carbonIntensity = new CarbonIntensity();
+        carbonIntensity.setZone("NL");
+        carbonIntensity.setResolution(Duration.ofHours(1));
+        carbonIntensity.setStart(Instant.parse("2024-01-01T00:00:00Z"));
+        carbonIntensity.setEnd(Instant.parse("2024-01-01T05:00:00Z"));
+        carbonIntensity.setData(List.of(
+                new BigDecimal("100"), // 00:00 - not tied
+                new BigDecimal("50"), // 01:00 - tied, chronologically first
+                new BigDecimal("50"), // 02:00 - tied, chronologically second
+                new BigDecimal("50"), // 03:00 - tied, chronologically third
+                new BigDecimal("200") // 04:00 - not tied
+        ));
+
+        ZonedDateTime ws = ZonedDateTime.parse("2024-01-01T00:00:00Z");
+        ZonedDateTime we = ws.plusHours(4);
+        Duration d = Duration.ofHours(1);
+
+        SingleJobStrategy strategy = new SingleJobStrategy(Duration.ofHours(1));
+        List<Timeslot> ranked = strategy.rankedTimeslots(ws, we, d, carbonIntensity);
+
+        assertThat(ranked).hasSize(5);
+        assertThat(ranked).extracting(Timeslot::start).containsExactly(
+                ws.plusHours(1), // 01:00, CI 50 - first among ties
+                ws.plusHours(2), // 02:00, CI 50 - second among ties
+                ws.plusHours(3), // 03:00, CI 50 - third among ties
+                ws, // 00:00, CI 100
+                ws.plusHours(4) // 04:00, CI 200
+        );
     }
 
     private CarbonIntensity loadCarbonIntensityFromFile(String fileName) {

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/strategy/TestSingleJobStrategy.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/strategy/TestSingleJobStrategy.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +32,23 @@ class TestSingleJobStrategy {
         assertThat(timeslot).isNotNull();
         assertThat(Duration.between(timeslot.start(), timeslot.end())).isEqualByComparingTo(d);
         assertThat(timeslot.carbonIntensity()).isLessThan(new BigDecimal("1135"));
+    }
+
+    @Test
+    void testRankedTimeslotsOrderedAscendingAndMatchesBestTimeslot() {
+        CarbonIntensity carbonIntensity = loadCarbonIntensityFromFile("day-ahead-20240824-Z.json");
+        ZonedDateTime ws = ZonedDateTime.parse("2024-08-27T00:00:00Z");
+        ZonedDateTime we = ws.plusHours(6);
+        Duration d = Duration.ofMinutes(30);
+
+        SingleJobStrategy strategy = new SingleJobStrategy();
+        List<Timeslot> ranked = strategy.rankedTimeslots(ws, we, d, carbonIntensity);
+
+        assertThat(ranked).isNotEmpty();
+        for (int i = 1; i < ranked.size(); i++) {
+            assertThat(ranked.get(i - 1).carbonIntensity()).isLessThanOrEqualTo(ranked.get(i).carbonIntensity());
+        }
+        assertThat(ranked.get(0)).usingRecursiveComparison().isEqualTo(strategy.bestTimeslot(ws, we, d, carbonIntensity));
     }
 
     private CarbonIntensity loadCarbonIntensityFromFile(String fileName) {

--- a/extensions/quarkus/runtime/src/main/java/io/carbonintensity/scheduler/quarkus/factory/GreenSchedulerProperties.java
+++ b/extensions/quarkus/runtime/src/main/java/io/carbonintensity/scheduler/quarkus/factory/GreenSchedulerProperties.java
@@ -32,6 +32,14 @@ public interface GreenSchedulerProperties {
     OptionalInt jobExecutors();
 
     /**
+     * Maximum number of jobs allowed to start at the exact same carbon-intensity slot within the same
+     * zone. Default 0 (disabled): jobs schedule independently and may land on the same moment. When set
+     * to a positive value, jobs beyond this limit for a given zone/slot are spread to the next-best slot
+     * instead, but a job's configured window always takes priority over this limit.
+     */
+    OptionalInt maxConcurrentPerSlot();
+
+    /**
      * Overdue grace period. Default 30 seconds.
      */
     Optional<Duration> overdueGracePeriod();

--- a/extensions/quarkus/runtime/src/main/java/io/carbonintensity/scheduler/quarkus/factory/SchedulerConfigBuilder.java
+++ b/extensions/quarkus/runtime/src/main/java/io/carbonintensity/scheduler/quarkus/factory/SchedulerConfigBuilder.java
@@ -15,6 +15,7 @@ public class SchedulerConfigBuilder {
     public static final Duration DEFAULT_OVERDUE_GRACE_PERIOD = SchedulerDefaults.DEFAULT_OVERDUE_GRACE_PERIOD;
     public static final Duration DEFAULT_SHUTDOWN_GRACE_PERIOD = SchedulerDefaults.DEFAULT_SHUTDOWN_GRACE_PERIOD;
     public static final int DEFAULT_NUMBER_OF_JOB_EXECUTORS = SchedulerDefaults.DEFAULT_NUMBER_OF_JOB_EXECUTORS;
+    public static final int DEFAULT_MAX_CONCURRENT_PER_SLOT = SchedulerDefaults.DEFAULT_MAX_CONCURRENT_PER_SLOT;
     public static final SchedulerConfig.StartMode DEFAULT_START_MODE = SchedulerConfig.StartMode.NORMAL;
     public static final String DEFAULT_API_URL = SchedulerDefaults.DEFAULT_API_URL;
     public static final Boolean DEFAULT_ENABLED = true;
@@ -22,6 +23,7 @@ public class SchedulerConfigBuilder {
     private boolean enabled;
     private SchedulerConfig.StartMode startMode;
     private Integer jobExecutorCount;
+    private Integer maxConcurrentPerSlot;
     private Duration shutdownGracePeriod;
     private Duration overdueGracePeriod;
     private String apiKey;
@@ -41,6 +43,7 @@ public class SchedulerConfigBuilder {
         enabled(properties.enabled().orElse(DEFAULT_ENABLED));
         startMode(properties.startMode().orElse(DEFAULT_START_MODE));
         jobExecutorCount(properties.jobExecutors().orElse(DEFAULT_NUMBER_OF_JOB_EXECUTORS));
+        maxConcurrentPerSlot(properties.maxConcurrentPerSlot().orElse(DEFAULT_MAX_CONCURRENT_PER_SLOT));
         overdueGracePeriod(properties.overdueGracePeriod().orElse(DEFAULT_OVERDUE_GRACE_PERIOD));
         shutdownGracePeriod(properties.shutdownGracePeriod().orElse(DEFAULT_SHUTDOWN_GRACE_PERIOD));
         apiUrl(properties.apiUrl().orElse(DEFAULT_API_URL));
@@ -57,6 +60,13 @@ public class SchedulerConfigBuilder {
         Assert.notNull(jobExecutors, "jobExecutors cannot be null");
         Assert.isTrue(jobExecutors > 0, "jobExecutors must be greater than 0");
         this.jobExecutorCount = jobExecutors;
+        return this;
+    }
+
+    public SchedulerConfigBuilder maxConcurrentPerSlot(Integer maxConcurrentPerSlot) {
+        Assert.notNull(maxConcurrentPerSlot, "maxConcurrentPerSlot cannot be null");
+        Assert.isTrue(maxConcurrentPerSlot >= 0, "maxConcurrentPerSlot must be greater than or equal to 0");
+        this.maxConcurrentPerSlot = maxConcurrentPerSlot;
         return this;
     }
 
@@ -114,6 +124,7 @@ public class SchedulerConfigBuilder {
         schedulerConfig.setOverdueGracePeriod(overdueGracePeriod);
         schedulerConfig.setShutdownGracePeriod(shutdownGracePeriod);
         schedulerConfig.setJobExecutors(jobExecutorCount);
+        schedulerConfig.setMaxConcurrentPerSlot(maxConcurrentPerSlot);
 
         if (this.carbonIntensityApi != null) {
             schedulerConfig.setCarbonIntensityApi(carbonIntensityApi);

--- a/extensions/spring-boot-starter/src/main/java/io/carbonintensity/scheduler/spring/GreenSchedulerProperties.java
+++ b/extensions/spring-boot-starter/src/main/java/io/carbonintensity/scheduler/spring/GreenSchedulerProperties.java
@@ -24,16 +24,19 @@ public class GreenSchedulerProperties {
     public static final Duration DEFAULT_OVERDUE_GRACE_PERIOD = SchedulerDefaults.DEFAULT_OVERDUE_GRACE_PERIOD;
     public static final Duration DEFAULT_SHUTDOWN_GRACE_PERIOD = SchedulerDefaults.DEFAULT_SHUTDOWN_GRACE_PERIOD;
     public static final int DEFAULT_NUMBER_OF_JOB_EXECUTORS = SchedulerDefaults.DEFAULT_NUMBER_OF_JOB_EXECUTORS;
+    public static final int DEFAULT_MAX_CONCURRENT_PER_SLOT = SchedulerDefaults.DEFAULT_MAX_CONCURRENT_PER_SLOT;
     public static final SchedulerConfig.StartMode DEFAULT_START_MODE = SchedulerConfig.StartMode.NORMAL;
     public static final String DEFAULT_API_URL = SchedulerDefaults.DEFAULT_API_URL;
     public static final Boolean DEFAULT_ENABLED = true;
 
     @ConstructorBinding // Required to generate metadata: https://stackoverflow.com/questions/79231534/how-can-i-use-optional-values-in-spring-boot-configuration-properties
     public GreenSchedulerProperties(Boolean enabled, SchedulerConfig.StartMode startMode, Integer jobExecutors,
-            Duration overdueGracePeriod, Duration shutdownGracePeriod, String apiKey, String apiUrl) {
+            Integer maxConcurrentPerSlot, Duration overdueGracePeriod, Duration shutdownGracePeriod, String apiKey,
+            String apiUrl) {
         this.enabled = Objects.requireNonNullElse(enabled, DEFAULT_ENABLED);
         this.startMode = Objects.requireNonNullElse(startMode, DEFAULT_START_MODE);
         this.jobExecutors = Objects.requireNonNullElse(jobExecutors, DEFAULT_NUMBER_OF_JOB_EXECUTORS);
+        this.maxConcurrentPerSlot = Objects.requireNonNullElse(maxConcurrentPerSlot, DEFAULT_MAX_CONCURRENT_PER_SLOT);
         this.overdueGracePeriod = Objects.requireNonNullElse(overdueGracePeriod, DEFAULT_OVERDUE_GRACE_PERIOD);
         this.shutdownGracePeriod = Objects.requireNonNullElse(shutdownGracePeriod, DEFAULT_SHUTDOWN_GRACE_PERIOD);
         this.apiKey = apiKey;
@@ -57,6 +60,14 @@ public class GreenSchedulerProperties {
      * Number of job executors. Default 10.
      */
     private Integer jobExecutors = DEFAULT_NUMBER_OF_JOB_EXECUTORS;
+
+    /**
+     * Maximum number of jobs allowed to start at the exact same carbon-intensity slot within the same
+     * zone. Default 0 (disabled): jobs schedule independently and may land on the same moment. When set
+     * to a positive value, jobs beyond this limit for a given zone/slot are spread to the next-best slot
+     * instead, but a job's configured window always takes priority over this limit.
+     */
+    private Integer maxConcurrentPerSlot = DEFAULT_MAX_CONCURRENT_PER_SLOT;
 
     /**
      * Overdue grace period. Default 30 seconds.
@@ -94,6 +105,15 @@ public class GreenSchedulerProperties {
      */
     public Optional<Integer> getJobExecutors() {
         return Optional.ofNullable(jobExecutors);
+    }
+
+    /**
+     * Gets the maximum number of jobs allowed to start at the exact same carbon-intensity slot.
+     *
+     * @return max concurrent jobs per slot
+     */
+    public Optional<Integer> getMaxConcurrentPerSlot() {
+        return Optional.ofNullable(maxConcurrentPerSlot);
     }
 
     /**

--- a/extensions/spring-boot-starter/src/main/java/io/carbonintensity/scheduler/spring/factory/SchedulerConfigBuilder.java
+++ b/extensions/spring-boot-starter/src/main/java/io/carbonintensity/scheduler/spring/factory/SchedulerConfigBuilder.java
@@ -17,6 +17,7 @@ public class SchedulerConfigBuilder {
     private boolean enabled;
     private SchedulerConfig.StartMode startMode;
     private Integer jobExecutorCount;
+    private Integer maxConcurrentPerSlot;
     private Duration shutdownGracePeriod;
     private Duration overdueGracePeriod;
     private String apiKey;
@@ -46,6 +47,8 @@ public class SchedulerConfigBuilder {
                 .ifPresent(this::startMode);
         properties.getJobExecutors()
                 .ifPresent(this::jobExecutorCount);
+        properties.getMaxConcurrentPerSlot()
+                .ifPresent(this::maxConcurrentPerSlot);
         properties.getOverdueGracePeriod()
                 .ifPresent(this::overdueGracePeriod);
         properties.getShutdownGracePeriod()
@@ -66,6 +69,13 @@ public class SchedulerConfigBuilder {
         Assert.notNull(jobExecutors, "jobExecutors cannot be null");
         Assert.isTrue(jobExecutors > 0, "jobExecutors must be greater than 0");
         this.jobExecutorCount = jobExecutors;
+        return this;
+    }
+
+    public SchedulerConfigBuilder maxConcurrentPerSlot(Integer maxConcurrentPerSlot) {
+        Assert.notNull(maxConcurrentPerSlot, "maxConcurrentPerSlot cannot be null");
+        Assert.isTrue(maxConcurrentPerSlot >= 0, "maxConcurrentPerSlot must be greater than or equal to 0");
+        this.maxConcurrentPerSlot = maxConcurrentPerSlot;
         return this;
     }
 
@@ -123,6 +133,7 @@ public class SchedulerConfigBuilder {
         schedulerConfig.setOverdueGracePeriod(overdueGracePeriod);
         schedulerConfig.setShutdownGracePeriod(shutdownGracePeriod);
         schedulerConfig.setJobExecutors(jobExecutorCount);
+        schedulerConfig.setMaxConcurrentPerSlot(maxConcurrentPerSlot);
 
         if (this.carbonIntensityApi != null) {
             schedulerConfig.setCarbonIntensityApi(carbonIntensityApi);

--- a/extensions/spring-boot-starter/src/test/java/io/carbonintensity/scheduler/spring/GreenScheduledPropertiesTests.java
+++ b/extensions/spring-boot-starter/src/test/java/io/carbonintensity/scheduler/spring/GreenScheduledPropertiesTests.java
@@ -17,6 +17,7 @@ class GreenScheduledPropertiesTests {
 
         assertThat(properties.getEnabled()).hasValue(true);
         assertThat(properties.getJobExecutors()).hasValue(DEFAULT_NUMBER_OF_JOB_EXECUTORS);
+        assertThat(properties.getMaxConcurrentPerSlot()).hasValue(DEFAULT_MAX_CONCURRENT_PER_SLOT);
         assertThat(properties.getOverdueGracePeriod()).hasValue(DEFAULT_OVERDUE_GRACE_PERIOD);
         assertThat(properties.getShutdownGracePeriod()).hasValue(DEFAULT_SHUTDOWN_GRACE_PERIOD);
         assertThat(properties.getApiUrl()).hasValue(DEFAULT_API_URL);
@@ -25,11 +26,12 @@ class GreenScheduledPropertiesTests {
 
     @Test
     void whenOverridingDefaultValues_thenSetOverriddenValues() {
-        GreenSchedulerProperties properties = new GreenSchedulerProperties(true, SchedulerConfig.StartMode.HALTED, 1,
+        GreenSchedulerProperties properties = new GreenSchedulerProperties(true, SchedulerConfig.StartMode.HALTED, 1, 2,
                 Duration.ofSeconds(1), Duration.ofSeconds(2), "apiKey", "apiUrl");
 
         assertThat(properties.getEnabled()).hasValue(true);
         assertThat(properties.getJobExecutors()).hasValue(1);
+        assertThat(properties.getMaxConcurrentPerSlot()).hasValue(2);
         assertThat(properties.getOverdueGracePeriod()).hasValue(Duration.ofSeconds(1));
         assertThat(properties.getShutdownGracePeriod()).hasValue(Duration.ofSeconds(2));
         assertThat(properties.getApiUrl()).hasValue("apiUrl");

--- a/extensions/spring-boot-starter/src/test/java/io/carbonintensity/scheduler/spring/factory/SchedulerConfigBuilderTests.java
+++ b/extensions/spring-boot-starter/src/test/java/io/carbonintensity/scheduler/spring/factory/SchedulerConfigBuilderTests.java
@@ -1,6 +1,7 @@
 package io.carbonintensity.scheduler.spring.factory;
 
 import static io.carbonintensity.scheduler.spring.GreenSchedulerProperties.DEFAULT_API_URL;
+import static io.carbonintensity.scheduler.spring.GreenSchedulerProperties.DEFAULT_MAX_CONCURRENT_PER_SLOT;
 import static io.carbonintensity.scheduler.spring.GreenSchedulerProperties.DEFAULT_NUMBER_OF_JOB_EXECUTORS;
 import static io.carbonintensity.scheduler.spring.GreenSchedulerProperties.DEFAULT_OVERDUE_GRACE_PERIOD;
 import static io.carbonintensity.scheduler.spring.GreenSchedulerProperties.DEFAULT_SHUTDOWN_GRACE_PERIOD;
@@ -37,6 +38,7 @@ class SchedulerConfigBuilderTests {
 
         assertThat(schedulerConfig.isEnabled()).isTrue();
         assertThat(schedulerConfig.getJobExecutors()).isEqualTo(DEFAULT_NUMBER_OF_JOB_EXECUTORS);
+        assertThat(schedulerConfig.getMaxConcurrentPerSlot()).isEqualTo(DEFAULT_MAX_CONCURRENT_PER_SLOT);
         assertThat(schedulerConfig.getStartMode()).isEqualTo(DEFAULT_START_MODE);
         assertThat(schedulerConfig.getOverdueGracePeriod()).isEqualTo(DEFAULT_OVERDUE_GRACE_PERIOD);
         assertThat(schedulerConfig.getShutdownGracePeriod()).isEqualTo(DEFAULT_SHUTDOWN_GRACE_PERIOD);
@@ -90,6 +92,30 @@ class SchedulerConfigBuilderTests {
     @ValueSource(ints = { 0, -1 })
     void whenSettingInvalidJobExecutorCount_thenThrowException(Integer jobExecutors) {
         assertThrows(IllegalArgumentException.class, () -> builder.jobExecutorCount(jobExecutors));
+    }
+
+    @Test
+    void testMaxConcurrentPerSlot() {
+        var schedulerConfig = builder
+                .maxConcurrentPerSlot(2)
+                .build();
+
+        assertThat(schedulerConfig.getMaxConcurrentPerSlot()).isEqualTo(2);
+        assertThrows(IllegalArgumentException.class, () -> builder.maxConcurrentPerSlot(null));
+    }
+
+    @Test
+    void whenSettingZeroMaxConcurrentPerSlot_thenDisablesSpreading() {
+        var schedulerConfig = builder
+                .maxConcurrentPerSlot(0)
+                .build();
+
+        assertThat(schedulerConfig.getMaxConcurrentPerSlot()).isZero();
+    }
+
+    @Test
+    void whenSettingNegativeMaxConcurrentPerSlot_thenThrowException() {
+        assertThrows(IllegalArgumentException.class, () -> builder.maxConcurrentPerSlot(-1));
     }
 
     @Test


### PR DESCRIPTION
Resolves #234.

## What

Today, every `@GreenScheduled` job picks its greenest moment independently. If several jobs in the same app target the same carbon-intensity zone and overlapping window, they can all land on the exact same instant — which can overload the machine if that's not desired.

This adds an **opt-in** `maxConcurrentPerSlot` property that limits how many jobs may start at the same slot within a zone. Jobs beyond that limit are moved to the next-best slot, taking each job's duration into account.

## How

- `ConcurrencySlotTracker` (new, `execution-planner`): per-zone bookkeeping of which slots are already claimed.
- `PlanningStrategy#rankedTimeslots(...)` (new): returns all candidate slots ordered by intensity instead of only the single best one; `bestTimeslot` now built on top of it.
- `FixedWindowPlanner` / `SuccessivePlanner`: new constructor overload accepting the tracker + limit. The existing single-arg constructor is untouched, so default behavior (limit disabled) is unchanged.
- `SchedulerConfig` / `SchedulerDefaults` + Quarkus and Spring Boot `GreenSchedulerProperties`: new `maxConcurrentPerSlot` property (`green-scheduler.max-concurrent-per-slot`), default `0` (disabled).
- A job's own configured window always wins over the limit: if no slot inside it still satisfies the limit, the job still runs at its greenest available slot inside the window, with a warning logged. This applies to both planners — both have a hard window in practice (`FixedWindowPlanner`'s explicit end, `SuccessivePlanner`'s `lastExecutionTime + maximumGap`).
- README: new "Scheduling multiple jobs" section documenting current (colliding) default behavior and the new opt-in property.

## Design notes

- Scope is intentionally JVM-local: coordinates different jobs within the same running application instance. Cross-instance/cluster-wide coordination between replicas of the same job is out of scope.
- Coordination is per zone + overlapping window, not global per application — jobs in different zones never compete for the same slots.
- Default is off (`0`) to avoid silently changing existing users' job timing on upgrade — this is additive, not a breaking change.

## Test plan

- [x] New/extended unit tests: `TestConcurrencySlotTracker`, `TestSingleJobStrategy` (ranking), `TestFixedWindowPlanner` (spreading + overflow/window-wins scenario)
- [x] Updated Spring Boot config tests (`GreenScheduledPropertiesTests`, `SchedulerConfigBuilderTests`) for the new property and constructor signature
- [x] Full module test suites pass: `execution-planner`, `core`, `extensions/spring-boot-starter`, `extensions/quarkus` (runtime, deployment, runtime-dev)