### PR TITLE
Add SuccessivePlanner test coverage for concurrency-limit spreading

### DIFF
--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/successive/TestSuccessivePlanner.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/successive/TestSuccessivePlanner.java
@@ -15,6 +15,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensityDataFetcher;
 import io.carbonintensity.executionplanner.runtime.impl.rest.CarbonIntensityJsonParser;
+import io.carbonintensity.executionplanner.spi.CarbonIntensityPlanner;
+import io.carbonintensity.executionplanner.spi.ConcurrencySlotTracker;
 
 @ExtendWith(MockitoExtension.class)
 class TestSuccessivePlanner {
@@ -26,6 +28,18 @@ class TestSuccessivePlanner {
     public void setup() {
         carbonIntensityDataFetcher = mock(CarbonIntensityDataFetcher.class);
         defaultCarbonIntensityScheduler = new SuccessivePlanner(carbonIntensityDataFetcher);
+    }
+
+    private static SuccessivePlanningConstraints constraintsFor(String identity, ZonedDateTime lastExecutionTime,
+            Duration minimumGap, Duration maximumGap) {
+        return DefaultSuccessivePlanningConstraints.builder()
+                .withIdentity(identity)
+                .withLastExecutionTime(lastExecutionTime)
+                .withMinimumGap(minimumGap)
+                .withMaximumGap(maximumGap)
+                .withDuration(Duration.ofMinutes(30))
+                .withCarbonIntensityZone("NL")
+                .build();
     }
 
     @Test
@@ -82,5 +96,69 @@ class TestSuccessivePlanner {
         // note: we allow the execution on the exact minGap, so should not be before (but equal or after)
         assertThat(nextExecutionTime.isBefore(lastExecutionTime.plus(minGap))).isFalse();
         assertThat(nextExecutionTime.isAfter(lastExecutionTime.plus(maxGap))).isFalse();
+    }
+
+    @Test
+    void whenTwoJobsCompeteForTheSameSlot_thenTheSecondJobIsSpreadToTheNextBestSlot() {
+        CarbonIntensityDataFetcher sharedFetcher = mock(CarbonIntensityDataFetcher.class);
+        CarbonIntensityJsonParser parser = new CarbonIntensityJsonParser();
+        var carbonIntensity = parser.parse(ClassLoader.getSystemResourceAsStream("day-ahead-20240824-Z.json"));
+        when(sharedFetcher.fetchCarbonIntensity(any())).thenReturn(carbonIntensity);
+
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+        CarbonIntensityPlanner<SuccessivePlanningConstraints> plannerA = new SuccessivePlanner(sharedFetcher, tracker, 1);
+        CarbonIntensityPlanner<SuccessivePlanningConstraints> plannerB = new SuccessivePlanner(sharedFetcher, tracker, 1);
+
+        ZonedDateTime lastExecutionTime = ZonedDateTime.parse("2024-08-27T00:00:00Z");
+        Duration minGap = Duration.ZERO;
+        Duration maxGap = Duration.ofHours(6);
+
+        ZonedDateTime timeA = plannerA.getNextExecutionTime(constraintsFor("job-a", lastExecutionTime, minGap, maxGap));
+        ZonedDateTime timeB = plannerB.getNextExecutionTime(constraintsFor("job-b", lastExecutionTime, minGap, maxGap));
+
+        assertThat(timeA).isNotNull();
+        assertThat(timeB).isNotNull();
+        assertThat(timeB).isNotEqualTo(timeA);
+    }
+
+    /**
+     * #234's design decision 5 claims that, unlike {@code FixedWindowPlanner}, "{@code SuccessivePlanner} has no
+     * such conflict since it can simply look further ahead" when no slot within the gap window satisfies the
+     * concurrency limit. That is not what the current implementation does: {@code SuccessivePlanner.pickTimeslot}
+     * ranks candidates via {@code strategy.rankedTimeslots(ws, we, ...)}, strictly bounded by the gap window
+     * {@code [ws, we]} (up to the maximum gap), exactly like {@code FixedWindowPlanner} is bounded by its fixed
+     * window. It never considers slots beyond {@code we}, so when the gap window is too narrow to offer an
+     * alternative slot, it falls back to the exact same "violate the limit, run at the greenest slot anyway"
+     * behavior as {@code FixedWindowPlanner} - it does not "look further ahead". This test documents that the two
+     * planners behave identically in this edge case, contradicting the "no such conflict" claim in #234.
+     */
+    @Test
+    void whenNoSlotSatisfiesTheLimit_thenTheGapWindowStillWinsAndJobRunsAnyway() {
+        CarbonIntensityDataFetcher sharedFetcher = mock(CarbonIntensityDataFetcher.class);
+        CarbonIntensityJsonParser parser = new CarbonIntensityJsonParser();
+        var carbonIntensity = parser.parse(ClassLoader.getSystemResourceAsStream("day-ahead-20240824-Z.json"));
+        when(sharedFetcher.fetchCarbonIntensity(any())).thenReturn(carbonIntensity);
+
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+        // minGap == maxGap collapses the gap window to a single instant, so exactly one candidate slot
+        // exists (see Timeslot.getTimeslots: candidates are generated for every resolution step in
+        // [ws, we], inclusive of we) - no alternative slot can ever exist
+        ZonedDateTime lastExecutionTime = ZonedDateTime.parse("2024-08-27T00:00:00Z");
+        Duration minGap = Duration.ofMinutes(30);
+        Duration maxGap = Duration.ofMinutes(30);
+        int maxConcurrentPerSlot = 1;
+
+        CarbonIntensityPlanner<SuccessivePlanningConstraints> plannerA = new SuccessivePlanner(sharedFetcher, tracker,
+                maxConcurrentPerSlot);
+        CarbonIntensityPlanner<SuccessivePlanningConstraints> plannerB = new SuccessivePlanner(sharedFetcher, tracker,
+                maxConcurrentPerSlot);
+
+        ZonedDateTime timeA = plannerA.getNextExecutionTime(constraintsFor("job-a", lastExecutionTime, minGap, maxGap));
+        ZonedDateTime timeB = plannerB.getNextExecutionTime(constraintsFor("job-b", lastExecutionTime, minGap, maxGap));
+
+        assertThat(timeA).isNotNull();
+        assertThat(timeB).isNotNull();
+        // no room to spread within this gap window: both jobs still run, at the same greenest slot
+        assertThat(timeB).isEqualTo(timeA);
     }
 }


### PR DESCRIPTION
## Summary

`FixedWindowPlanner` got a `ConcurrencySlotTracker` + `maxConcurrentPerSlot` constructor overload in #235, and `TestFixedWindowPlanner.java` was updated with matching tests. `SuccessivePlanner` got the equivalent constructor overload, but `TestSuccessivePlanner.java` was not touched.

This PR adds that missing coverage, mirroring `TestFixedWindowPlanner`'s two tests:

- `whenTwoJobsCompeteForTheSameSlot_thenTheSecondJobIsSpreadToTheNextBestSlot` — two jobs competing for the same slot get spread across slots when the gap window is wide enough.
- `whenNoSlotSatisfiesTheLimit_thenTheGapWindowStillWinsAndJobRunsAnyway` — when the gap window offers no alternative slot, the limit is violated (best-effort) and both jobs land on the same greenest slot.

## Correcting the record on #234 design decision 5

#234's design decision 5 states: *"SuccessivePlanner has no such conflict since it can simply look further ahead"* (unlike `FixedWindowPlanner`, which has a hard window and may have to violate the limit to honor it).

**That claim is inaccurate**, not just "confirmed compatible." Reading `SuccessivePlanner.pickTimeslot(...)` on `feature/234-spread-scheduled-jobs` shows it ranks candidates via `strategy.rankedTimeslots(ws, we, ...)`, strictly bounded by its own gap window `[ws, we]` — computed as `initialStartTime .. initialStartTime + initialMaximumDelay` on first run, or `lastExecutionTime + minimumGap .. lastExecutionTime + maximumGap` on subsequent runs. It never considers slots beyond `we`. When no candidate within that window satisfies `maxConcurrentPerSlot`, it falls back to running at the greenest slot in the window regardless of the limit — structurally identical to `FixedWindowPlanner`'s fallback, down to its own `log.warn(...)` ("...to honor its gap window").

The second test above exercises exactly that fallback path and confirms it (verified the `log.warn` fires during the test run). This matches the independent finding on the sibling ADR ticket (#245 / PR #249), which documents the same divergence in `docs/adr/0002-spread-concurrent-scheduled-jobs.md`.

## Test plan

- [x] `./mvnw test -Dtest=TestSuccessivePlanner,TestFixedWindowPlanner` — 10/10 pass
- [x] `./mvnw test` (full `execution-planner` module) — 41/41 pass, `BUILD SUCCESS`

Part of #243, resolves #244