### PR TITLE
Pin tie-break order for equal-carbon-intensity slots

### DIFF
--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/fixedwindow/TestFixedWindowPlanner.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/fixedwindow/TestFixedWindowPlanner.java
@@ -5,10 +5,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.math.BigDecimal;
 import java.time.DayOfWeek;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,6 +23,7 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
 
+import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensity;
 import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensityDataFetcher;
 import io.carbonintensity.executionplanner.runtime.impl.rest.CarbonIntensityJsonParser;
 import io.carbonintensity.executionplanner.spi.CarbonIntensityPlanner;
@@ -38,13 +42,18 @@ class TestFixedWindowPlanner {
     }
 
     private static FixedWindowPlanningConstraints constraintsFor(String identity, ZonedDateTime start, ZonedDateTime end) {
+        return constraintsFor(identity, start, end, Duration.ofMinutes(30));
+    }
+
+    private static FixedWindowPlanningConstraints constraintsFor(String identity, ZonedDateTime start, ZonedDateTime end,
+            Duration duration) {
         CronParser cronParser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
         Cron cron = cronParser.parse(String.format("%d %d %d * * ?", start.getSecond(), start.getMinute(), start.getHour()));
         Cron cronFallback = cronParser.parse("0 0 12 * * ?");
 
         return DefaultFixedWindowPlanningConstraints.builder()
                 .withIdentity(identity)
-                .withDuration(Duration.ofMinutes(30))
+                .withDuration(duration)
                 .withCarbonIntensityZone("NL")
                 .withCronExpression(cron)
                 .withStartAndEnd(start, end)
@@ -102,6 +111,50 @@ class TestFixedWindowPlanner {
         assertThat(timeB).isNotNull();
         // no room to spread within this window: both jobs still run, at the same greenest slot
         assertThat(timeB).isEqualTo(timeA);
+    }
+
+    /**
+     * When several candidate slots tie on carbon intensity, {@code SingleJobStrategy#rankedTimeslots}
+     * breaks the tie by chronological order (see {@code TestSingleJobStrategy}). This pins that the same
+     * deterministic order is what spreading walks through here: competing jobs land on the tied slots in
+     * chronological order, not in some incidental order.
+     */
+    @Test
+    void whenThreeJobsCompeteForTiedSlots_thenTheyAreSpreadInChronologicalOrder() {
+        CarbonIntensityDataFetcher sharedFetcher = mock(CarbonIntensityDataFetcher.class);
+
+        // hourly data: 01:00, 02:00 and 03:00 all tie at 50, so with a 1-hour job duration those three
+        // timeslots are the tied candidates; 00:00 (100) and 04:00 (200) are strictly worse.
+        CarbonIntensity carbonIntensity = new CarbonIntensity();
+        carbonIntensity.setZone("NL");
+        carbonIntensity.setResolution(Duration.ofHours(1));
+        carbonIntensity.setStart(Instant.parse("2024-01-01T00:00:00Z"));
+        carbonIntensity.setEnd(Instant.parse("2024-01-01T05:00:00Z"));
+        carbonIntensity.setData(List.of(
+                new BigDecimal("100"),
+                new BigDecimal("50"),
+                new BigDecimal("50"),
+                new BigDecimal("50"),
+                new BigDecimal("200")));
+        when(sharedFetcher.fetchCarbonIntensity(any())).thenReturn(carbonIntensity);
+
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+        CarbonIntensityPlanner<FixedWindowPlanningConstraints> plannerA = new FixedWindowPlanner(sharedFetcher, tracker, 1);
+        CarbonIntensityPlanner<FixedWindowPlanningConstraints> plannerB = new FixedWindowPlanner(sharedFetcher, tracker, 1);
+        CarbonIntensityPlanner<FixedWindowPlanningConstraints> plannerC = new FixedWindowPlanner(sharedFetcher, tracker, 1);
+
+        ZonedDateTime ws = ZonedDateTime.parse("2024-01-01T00:00:00Z");
+        ZonedDateTime we = ws.plusHours(4);
+        Duration duration = Duration.ofHours(1);
+
+        ZonedDateTime timeA = plannerA.getNextExecutionTime(constraintsFor("job-a", ws, we, duration));
+        ZonedDateTime timeB = plannerB.getNextExecutionTime(constraintsFor("job-b", ws, we, duration));
+        ZonedDateTime timeC = plannerC.getNextExecutionTime(constraintsFor("job-c", ws, we, duration));
+
+        // the three tied (CI 50) slots are claimed in chronological order: 01:00, then 02:00, then 03:00
+        assertThat(timeA).isEqualTo(ws.plusHours(1));
+        assertThat(timeB).isEqualTo(ws.plusHours(2));
+        assertThat(timeC).isEqualTo(ws.plusHours(3));
     }
 
     @Test

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/strategy/TestSingleJobStrategy.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/strategy/TestSingleJobStrategy.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -49,6 +50,47 @@ class TestSingleJobStrategy {
             assertThat(ranked.get(i - 1).carbonIntensity()).isLessThanOrEqualTo(ranked.get(i).carbonIntensity());
         }
         assertThat(ranked.get(0)).usingRecursiveComparison().isEqualTo(strategy.bestTimeslot(ws, we, d, carbonIntensity));
+    }
+
+    /**
+     * {@link SingleJobStrategy#rankedTimeslots} sorts with {@link java.util.List#sort}, which is a stable
+     * sort. On a tie in carbon intensity, this pins the deliberate (not accidental) tie-break: the
+     * chronologically earliest tied slot stays ranked first, then the next earliest, and so on - because
+     * {@link io.carbonintensity.executionplanner.planner.Timeslot#getTimeslots} generates candidate slots
+     * in chronological order in the first place, and a stable sort never reorders equal elements.
+     */
+    @Test
+    void testRankedTimeslotsBreaksTiesByChronologicalOrder() {
+        // hourly data, resolution matches the 1-hour job duration and slot-generation resolution below,
+        // so each generated timeslot lines up exactly with one data point: 100, 50, 50, 50, 200
+        CarbonIntensity carbonIntensity = new CarbonIntensity();
+        carbonIntensity.setZone("NL");
+        carbonIntensity.setResolution(Duration.ofHours(1));
+        carbonIntensity.setStart(Instant.parse("2024-01-01T00:00:00Z"));
+        carbonIntensity.setEnd(Instant.parse("2024-01-01T05:00:00Z"));
+        carbonIntensity.setData(List.of(
+                new BigDecimal("100"), // 00:00 - not tied
+                new BigDecimal("50"), // 01:00 - tied, chronologically first
+                new BigDecimal("50"), // 02:00 - tied, chronologically second
+                new BigDecimal("50"), // 03:00 - tied, chronologically third
+                new BigDecimal("200") // 04:00 - not tied
+        ));
+
+        ZonedDateTime ws = ZonedDateTime.parse("2024-01-01T00:00:00Z");
+        ZonedDateTime we = ws.plusHours(4);
+        Duration d = Duration.ofHours(1);
+
+        SingleJobStrategy strategy = new SingleJobStrategy(Duration.ofHours(1));
+        List<Timeslot> ranked = strategy.rankedTimeslots(ws, we, d, carbonIntensity);
+
+        assertThat(ranked).hasSize(5);
+        assertThat(ranked).extracting(Timeslot::start).containsExactly(
+                ws.plusHours(1), // 01:00, CI 50 - first among ties
+                ws.plusHours(2), // 02:00, CI 50 - second among ties
+                ws.plusHours(3), // 03:00, CI 50 - third among ties
+                ws, // 00:00, CI 100
+                ws.plusHours(4) // 04:00, CI 200
+        );
     }
 
     private CarbonIntensity loadCarbonIntensityFromFile(String fileName) {


### PR DESCRIPTION
Part of #243, resolves #247

## Question

`SingleJobStrategy#rankedTimeslots` / `FixedWindowPlanner#pickTimeslot`: what happens when multiple candidate slots tie on carbon intensity? No test pinned this down before.

## Finding

`rankedTimeslots` sorts candidate `Timeslot`s with `List#sort`, which is a **stable sort** (`Comparator.comparing(Timeslot::carbonIntensity)`), and `Timeslot.getTimeslots` generates those candidates in strict chronological order in the first place. So on a tie, the chronologically **earliest** tied slot sorts first, then the next earliest, and so on.

This is deterministic - not a `HashMap`-iteration-order accident - but it was an implicit consequence of implementation choices (stable sort + chronological generation order) rather than a behavior anyone had deliberately pinned down or tested. `FixedWindowPlanner#pickTimeslot` walks that same ranked list for concurrency spreading, so the tie-break order also determines the order in which competing jobs claim tied slots.

No production code was changed - the existing behavior is correct and desirable (earliest tied slot wins, consistent with "prefer sooner over later, all else equal").

## What changed

- `TestSingleJobStrategy#testRankedTimeslotsBreaksTiesByChronologicalOrder` - builds a synthetic `CarbonIntensity` with three tied hourly slots among two non-tied ones, and asserts `rankedTimeslots` returns them in chronological order among the tie.
- `TestFixedWindowPlanner#whenThreeJobsCompeteForTiedSlots_thenTheyAreSpreadInChronologicalOrder` - same synthetic data, three competing jobs with `maxConcurrentPerSlot=1`; asserts they claim the three tied slots in chronological order (01:00, 02:00, 03:00).

## Test plan

- [x] `./mvnw -Dtest=TestSingleJobStrategy,TestFixedWindowPlanner,TestSuccessivePlanner test` (run from `execution-planner/`) - all 12 tests pass, including the 2 new ones.