### PR TITLE
Actually fix build silently skipping on push to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,14 +56,17 @@ jobs:
     needs: check
     # `check` only runs for pull_request events (see its `if` above) - it needs a base ref to
     # diff against, which a push doesn't have. On any other trigger (a push to main,
-    # workflow_dispatch, ...) `check` is skipped, and a skipped job's outputs are an empty
-    # string, not false. A bare `needs.check.outputs.code_changed == 'true'` here used to
-    # silently skip `build` on every push to main - confirmed in the Actions history, every
-    # push-triggered run before this fix shows the job skipped, for well over a year - not
-    # because anything failed, but because there was nothing to compare against. The
-    # `github.event_name != 'pull_request' ||` short-circuit is what makes every push actually
-    # build, while pull requests keep the doc-only-change optimization `check` exists for.
-    if: github.event_name != 'pull_request' || needs.check.outputs.code_changed == 'true'
+    # workflow_dispatch, ...) `check` is skipped.
+    #
+    # A previous fix here added `github.event_name != 'pull_request' ||` so the OR would be
+    # true on a push regardless of `check`'s (empty, not "false") output. That's necessary but
+    # not sufficient: GitHub Actions skips a job by default whenever any of its `needs` jobs
+    # was itself skipped, regardless of what the job's own `if` evaluates to - `always()` is
+    # required to opt out of that. Without it, `build` kept silently skipping on every push to
+    # main, exactly like before, because `check` skips on push and that alone was enough to
+    # skip `build` too, before its `if` was ever evaluated. Confirmed via the Actions API on a
+    # non-docs push commit: both jobs completed with zero steps run.
+    if: always() && (github.event_name != 'pull_request' || needs.check.outputs.code_changed == 'true')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description
The `build` job on push to `main` has been silently skipped again since #221 (the earlier attempt to fix this). That earlier fix made `build`'s `if` condition logically true on a push (`github.event_name != 'pull_request' || ...`), but missed that GitHub Actions skips a job by default whenever any of its `needs` jobs was itself skipped - regardless of what the job's own `if` evaluates to - unless `always()` is used. `check` (which `build` depends on via `needs`) only runs on `pull_request` events, so it's always skipped on a push, and that alone kept dragging `build` down with it before its own condition was ever evaluated.

This adds the missing `always()`. Verified on this branch itself: a push here (which triggers `build.yml` as a push event, same as a push to `main` would) now actually runs `build` end to end instead of skipping it.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues
None filed - found while looking into whether `main` was still being verified after every merge.

## How I verified this
- Pushed this branch and watched the resulting `Build` workflow run (event: `push`) - `build` executed all its steps and finished green, `check` stayed skipped as expected (it's PR-only): https://github.com/carbonintensityio/green-scheduler/actions/runs/33457221790
- Also ran `./mvnw -B --settings .github/mvn-settings.xml -Dno-format verify` locally against current `main` to confirm there's nothing currently broken that this now-working safety net would have caught.

## Checklist
- [x] Formatted according to the [CONTRIBUTING guidelines](../CONTRIBUTING.md)
- [x] Follows the [coding guidelines](../CONTRIBUTING.md#coding-guidelines)
- [ ] Follows the [logging guidelines](../CONTRIBUTING.md#logging-guidelines) - N/A, workflow-only change
- [x] `./mvnw -B --settings .github/mvn-settings.xml -Dno-format verify` runs successfully
- [ ] Tests:
  - [ ] A new test covers this
  - [ ] An existing test already covers it
  - [x] Not testable - GitHub Actions workflow logic, verified via an actual push-triggered run instead (see above)
- [x] I signed off my commits (`git commit -s`) per this project's [DCO requirement](../dco.txt)
