### PR TITLE
Add explicit tests proving per-zone slot isolation

### DIFF
--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/fixedwindow/TestFixedWindowPlanner.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/fixedwindow/TestFixedWindowPlanner.java
@@ -38,6 +38,11 @@ class TestFixedWindowPlanner {
     }
 
     private static FixedWindowPlanningConstraints constraintsFor(String identity, ZonedDateTime start, ZonedDateTime end) {
+        return constraintsFor(identity, "NL", start, end);
+    }
+
+    private static FixedWindowPlanningConstraints constraintsFor(String identity, String zone, ZonedDateTime start,
+            ZonedDateTime end) {
         CronParser cronParser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
         Cron cron = cronParser.parse(String.format("%d %d %d * * ?", start.getSecond(), start.getMinute(), start.getHour()));
         Cron cronFallback = cronParser.parse("0 0 12 * * ?");
@@ -45,7 +50,7 @@ class TestFixedWindowPlanner {
         return DefaultFixedWindowPlanningConstraints.builder()
                 .withIdentity(identity)
                 .withDuration(Duration.ofMinutes(30))
-                .withCarbonIntensityZone("NL")
+                .withCarbonIntensityZone(zone)
                 .withCronExpression(cron)
                 .withStartAndEnd(start, end)
                 .withFallbackCronExpression(cronFallback)
@@ -75,6 +80,34 @@ class TestFixedWindowPlanner {
         assertThat(timeA).isNotNull();
         assertThat(timeB).isNotNull();
         assertThat(timeB).isNotEqualTo(timeA);
+    }
+
+    @Test
+    void whenTwoJobsInDifferentZonesCompeteForTheSameSlot_thenNeitherIsSpread() {
+        CarbonIntensityDataFetcher sharedFetcher = mock(CarbonIntensityDataFetcher.class);
+        CarbonIntensityJsonParser parser = new CarbonIntensityJsonParser();
+        var carbonIntensity = parser.parse(ClassLoader.getSystemResourceAsStream("day-ahead-20240824-Z.json"));
+        // Same fixture regardless of zone is fine here: what matters is that both jobs independently
+        // resolve to the same greenest instant, and neither gets bumped because of the other's zone.
+        when(sharedFetcher.fetchCarbonIntensity(any())).thenReturn(carbonIntensity);
+
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+        CarbonIntensityPlanner<FixedWindowPlanningConstraints> plannerA = new FixedWindowPlanner(sharedFetcher, tracker, 1);
+        CarbonIntensityPlanner<FixedWindowPlanningConstraints> plannerB = new FixedWindowPlanner(sharedFetcher, tracker, 1);
+
+        ZonedDateTime ws = ZonedDateTime.parse("2024-08-27T00:00:00Z");
+        ZonedDateTime we = ws.plusHours(6);
+        var constraintsA = constraintsFor("job-a", "NL", ws, we);
+        var constraintsB = constraintsFor("job-b", "DE", ws, we);
+
+        ZonedDateTime timeA = plannerA.getNextExecutionTime(constraintsA);
+        ZonedDateTime timeB = plannerB.getNextExecutionTime(constraintsB);
+
+        assertThat(timeA).isNotNull();
+        assertThat(timeB).isNotNull();
+        // Different zones never compete for the same slot count: job-b lands on the exact same
+        // instant as job-a instead of being spread to the next-best slot.
+        assertThat(timeB).isEqualTo(timeA);
     }
 
     @Test

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/spi/TestConcurrencySlotTracker.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/spi/TestConcurrencySlotTracker.java
@@ -44,6 +44,25 @@ class TestConcurrencySlotTracker {
     }
 
     @Test
+    void twoZonesCanIndependentlyReserveTheExactSameInstant() {
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+
+        // Two jobs in different zones both want the exact same instant. Neither should see the
+        // other's reservation: coordination is per zone, never global.
+        tracker.reserve(ZONE_A, "job-a1", SLOT);
+        tracker.reserve(ZONE_B, "job-b1", SLOT);
+
+        // Each was the first (and only) reservation in its own zone, so each sees zero competitors
+        // at that instant - i.e. neither would be bumped to a later slot.
+        assertThat(tracker.countOthersAt(ZONE_A, "job-a1", SLOT)).isZero();
+        assertThat(tracker.countOthersAt(ZONE_B, "job-b1", SLOT)).isZero();
+
+        // A second job arriving in either zone only competes with reservations in that same zone.
+        assertThat(tracker.countOthersAt(ZONE_A, "job-a2", SLOT)).isEqualTo(1);
+        assertThat(tracker.countOthersAt(ZONE_B, "job-b2", SLOT)).isEqualTo(1);
+    }
+
+    @Test
     void countOthersAtIsZeroForAnUnreservedSlot() {
         ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
 


### PR DESCRIPTION
Part of #243, resolves #248

## Question being answered

green-scheduler#234's design decision 2 says coordination for `maxConcurrentPerSlot` is per zone + overlapping window, never global: jobs targeting different carbon-intensity zones must have independent optimal moments and must never artificially compete for the same slot count.

`ConcurrencySlotTracker`'s `slotsByZone` map is keyed by zone, which structurally implies this isolation, but none of the existing tests (`TestConcurrencySlotTracker`, `TestSingleJobStrategy`, `TestFixedWindowPlanner`) explicitly proved that two jobs in different zones landing on the exact same instant never affect each other's slot counts.

## What this adds

- `TestConcurrencySlotTracker#twoZonesCanIndependentlyReserveTheExactSameInstant` — a focused unit-level proof: two jobs in different zones reserve the identical `Instant`, and `countOthersAt` for each zone is unaffected by the other zone's reservation (each zone's first reservation sees 0 others, each zone's second sees 1, scoped strictly to its own zone).
- `TestFixedWindowPlanner#whenTwoJobsInDifferentZonesCompeteForTheSameSlot_thenNeitherIsSpread` — an end-to-end proof: two jobs in different zones (`NL`/`DE`), sharing a `ConcurrencySlotTracker` with `maxConcurrentPerSlot = 1`, both resolve to the exact same greenest instant instead of the second job being spread to a later slot (contrast with the existing same-zone test, which asserts the opposite).

## Outcome

Zone isolation holds as designed — no bug found, no production code changes. I traced both tests against the actual `ConcurrencySlotTracker` (isolation keyed strictly through `slotsByZone.get(zone)`) and `SingleJobStrategy.rankedTimeslots` (ranking has no zone dependency, so identical window/duration/data across zones deterministically yields the same top slot) to confirm the assertions aren't incidental.

## Test plan

- [x] `./mvnw -f execution-planner/pom.xml -Dtest=TestConcurrencySlotTracker,TestFixedWindowPlanner,TestSingleJobStrategy test` — 14 tests, all green
- [x] `./mvnw -f execution-planner/pom.xml -Dno-format verify` (CI's exact formatting-validation flags) — passes