### PR TITLE
Fix compatibility-monitor's report job silently dropping all but the last result

### DIFF
--- a/.github/workflows/compatibility-monitor.yml
+++ b/.github/workflows/compatibility-monitor.yml
@@ -191,7 +191,13 @@ jobs:
         with:
           pattern: 'result-*'
           path: results
-          merge-multiple: true
+          # Deliberately NOT merge-multiple: every per-combination artifact uploads the exact same
+          # inner path ("results/result.json" - see "Upload result" above), only the artifact name
+          # itself is unique. merge-multiple extracts every matching artifact into one shared
+          # directory, so same-named files silently overwrite each other and only the
+          # last-downloaded combination's result survives - see green-scheduler#263. Without it,
+          # download-artifact gives each artifact its own subdirectory (named after the artifact)
+          # under `path`, so nothing collides.
 
       - name: Aggregate per key and report
         env:
@@ -200,7 +206,8 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
-          files=(results/*.json)
+          # One subdirectory per artifact (see "Download results" above), so recurse one level.
+          files=(results/*/*.json)
           if [ "${#files[@]}" -eq 0 ]; then
             echo "No compatibility results were uploaded - nothing to report." >&2
             exit 1


### PR DESCRIPTION
## Description

Fixes #263.

## Root cause

Every per-combination job in `compatibility-monitor.yml` uploads its result as an artifact named `result-<framework>-<line>-<tier>-jdk<java>` (unique), but the file *inside* every one of those artifacts is always `results/result.json` (identical path). The `report` job downloads everything matching `result-*` with `merge-multiple: true`, which extracts every matched artifact into the *same* shared directory - so same-named files silently overwrite each other, and only whichever artifact happens to be downloaded last survives on disk. The aggregation step then only ever sees that one surviving `result.json`, reports on that single key, and still exits 0 (the job "succeeds").

This is exactly what happened in [run 33621809188](https://github.com/carbonintensityio/green-scheduler/actions/runs/33621809188) (the manual `scope=all` run against the freshly-published v0.8.4, see #262): out of 12 uploaded results across 7 keys, only `spring-boot:4.0:required` (a success) survived the merge and got reported - the real `quarkus:3.27:required` failure was silently dropped, so no tracking issue was opened automatically.

I originally suspected a `while read` / stdin-consumption bug in the aggregation loop itself (see the original #263 report) - that turned out to be wrong. Reproduced locally: a plain bash loop over `report-failure` with several real keys and real `gh` calls processes every key correctly. The actual cause is the artifact merge collision described above, confirmed by noting that the one key that *did* survive is the last artifact in that run's own "Download results" log.

## Fix

- Removed `merge-multiple: true` from the "Download results" step, so `download-artifact@v4` gives each matched artifact its own subdirectory (named after the artifact) instead of flattening everything into one directory.
- Updated the aggregation step's glob from `results/*.json` to `results/*/*.json` to match.

## Verification

Reproduced the collision locally (two artifacts each containing `result.json`, downloaded/merged into one directory → only the second's content survives). Reproduced the *fix* locally too: with per-artifact subdirectories (matching `download-artifact@v4`'s default, non-merge-multiple layout) and 3 result files including a real `quarkus:3.27:required` failure, `results/*/*.json` finds all of them and both keys aggregate correctly - nothing is silently dropped.