### PR TITLE
Make ConcurrencySlotTracker atomic via tryReserve()

### DIFF
--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/fixedwindow/FixedWindowPlanner.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/fixedwindow/FixedWindowPlanner.java
@@ -102,8 +102,7 @@ public class FixedWindowPlanner implements CarbonIntensityPlanner<FixedWindowPla
         String zone = constraints.getCarbonIntensityZone();
         String identity = constraints.getIdentity();
         for (Timeslot candidate : ranked) {
-            if (slotTracker.countOthersAt(zone, identity, candidate.start().toInstant()) < maxConcurrentPerSlot) {
-                slotTracker.reserve(zone, identity, candidate.start().toInstant());
+            if (slotTracker.tryReserve(zone, identity, candidate.start().toInstant(), maxConcurrentPerSlot)) {
                 return candidate.start();
             }
         }

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/successive/SuccessivePlanner.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/successive/SuccessivePlanner.java
@@ -110,8 +110,7 @@ public class SuccessivePlanner implements CarbonIntensityPlanner<SuccessivePlann
         String zone = constraints.getCarbonIntensityZone();
         String identity = constraints.getIdentity();
         for (Timeslot candidate : ranked) {
-            if (slotTracker.countOthersAt(zone, identity, candidate.start().toInstant()) < maxConcurrentPerSlot) {
-                slotTracker.reserve(zone, identity, candidate.start().toInstant());
+            if (slotTracker.tryReserve(zone, identity, candidate.start().toInstant(), maxConcurrentPerSlot)) {
                 return candidate.start();
             }
         }

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/spi/ConcurrencySlotTracker.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/spi/ConcurrencySlotTracker.java
@@ -13,17 +13,64 @@ import java.util.concurrent.ConcurrentMap;
  * A single tracker instance is meant to be shared by all jobs scheduled within one application instance.
  * It only coordinates jobs known to this JVM - it is not intended to coordinate scheduling across a
  * cluster of application instances.
+ * <p>
+ * All three public methods are serialized per zone (via an internal per-zone lock), so concurrent callers
+ * targeting the same zone never observe a torn intermediate state and {@link #tryReserve} is a genuine
+ * check-and-reserve compound operation, not a check-then-act race. Two different zones never contend on
+ * the same lock, preserving the existing zone-isolation guarantee.
  */
 public class ConcurrencySlotTracker {
 
     private final ConcurrentMap<String, ConcurrentMap<Instant, Set<String>>> slotsByZone = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, ConcurrentMap<String, Instant>> reservedSlotByZoneAndIdentity = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Object> zoneLocks = new ConcurrentHashMap<>();
 
     /**
      * Reserves the given slot for the given job identity within the given zone, replacing any previous
-     * reservation this identity held in that zone.
+     * reservation this identity held in that zone, regardless of how many other identities already
+     * occupy that slot. Used for the "the job's own window always wins" fallback - prefer
+     * {@link #tryReserve} when a concurrency limit should actually be enforced.
      */
     public void reserve(String zone, String jobIdentity, Instant slotStart) {
+        synchronized (lockFor(zone)) {
+            reserveLocked(zone, jobIdentity, slotStart);
+        }
+    }
+
+    /**
+     * @return the number of job identities, other than {@code jobIdentity} itself, already reserved to
+     *         start at {@code slotStart} within {@code zone}.
+     */
+    public int countOthersAt(String zone, String jobIdentity, Instant slotStart) {
+        synchronized (lockFor(zone)) {
+            return countOthersAtLocked(zone, jobIdentity, slotStart);
+        }
+    }
+
+    /**
+     * Atomically checks whether fewer than {@code maxConcurrentPerSlot} other identities already occupy
+     * {@code slotStart} within {@code zone}, and if so, reserves it for {@code jobIdentity} - all under
+     * the same per-zone lock, so no other {@code tryReserve}/{@code reserve}/{@code countOthersAt} call
+     * for the same zone can interleave between the check and the reservation.
+     *
+     * @return {@code true} if the slot was reserved; {@code false} if the limit was already reached, in
+     *         which case no state is changed.
+     */
+    public boolean tryReserve(String zone, String jobIdentity, Instant slotStart, int maxConcurrentPerSlot) {
+        synchronized (lockFor(zone)) {
+            if (countOthersAtLocked(zone, jobIdentity, slotStart) >= maxConcurrentPerSlot) {
+                return false;
+            }
+            reserveLocked(zone, jobIdentity, slotStart);
+            return true;
+        }
+    }
+
+    private Object lockFor(String zone) {
+        return zoneLocks.computeIfAbsent(zone, z -> new Object());
+    }
+
+    private void reserveLocked(String zone, String jobIdentity, Instant slotStart) {
         ConcurrentMap<String, Instant> reservedByIdentity = reservedSlotByZoneAndIdentity.computeIfAbsent(zone,
                 z -> new ConcurrentHashMap<>());
         ConcurrentMap<Instant, Set<String>> slots = slotsByZone.computeIfAbsent(zone, z -> new ConcurrentHashMap<>());
@@ -41,11 +88,7 @@ public class ConcurrencySlotTracker {
         slots.computeIfAbsent(slotStart, s -> ConcurrentHashMap.newKeySet()).add(jobIdentity);
     }
 
-    /**
-     * @return the number of job identities, other than {@code jobIdentity} itself, already reserved to
-     *         start at {@code slotStart} within {@code zone}.
-     */
-    public int countOthersAt(String zone, String jobIdentity, Instant slotStart) {
+    private int countOthersAtLocked(String zone, String jobIdentity, Instant slotStart) {
         ConcurrentMap<Instant, Set<String>> slots = slotsByZone.get(zone);
         if (slots == null) {
             return 0;

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/fixedwindow/TestFixedWindowPlanner.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/fixedwindow/TestFixedWindowPlanner.java
@@ -42,11 +42,21 @@ class TestFixedWindowPlanner {
     }
 
     private static FixedWindowPlanningConstraints constraintsFor(String identity, ZonedDateTime start, ZonedDateTime end) {
-        return constraintsFor(identity, start, end, Duration.ofMinutes(30));
+        return constraintsFor(identity, "NL", start, end, Duration.ofMinutes(30));
     }
 
     private static FixedWindowPlanningConstraints constraintsFor(String identity, ZonedDateTime start, ZonedDateTime end,
             Duration duration) {
+        return constraintsFor(identity, "NL", start, end, duration);
+    }
+
+    private static FixedWindowPlanningConstraints constraintsFor(String identity, String zone, ZonedDateTime start,
+            ZonedDateTime end) {
+        return constraintsFor(identity, zone, start, end, Duration.ofMinutes(30));
+    }
+
+    private static FixedWindowPlanningConstraints constraintsFor(String identity, String zone, ZonedDateTime start,
+            ZonedDateTime end, Duration duration) {
         CronParser cronParser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
         Cron cron = cronParser.parse(String.format("%d %d %d * * ?", start.getSecond(), start.getMinute(), start.getHour()));
         Cron cronFallback = cronParser.parse("0 0 12 * * ?");
@@ -54,7 +64,7 @@ class TestFixedWindowPlanner {
         return DefaultFixedWindowPlanningConstraints.builder()
                 .withIdentity(identity)
                 .withDuration(duration)
-                .withCarbonIntensityZone("NL")
+                .withCarbonIntensityZone(zone)
                 .withCronExpression(cron)
                 .withStartAndEnd(start, end)
                 .withFallbackCronExpression(cronFallback)
@@ -84,6 +94,34 @@ class TestFixedWindowPlanner {
         assertThat(timeA).isNotNull();
         assertThat(timeB).isNotNull();
         assertThat(timeB).isNotEqualTo(timeA);
+    }
+
+    @Test
+    void whenTwoJobsInDifferentZonesCompeteForTheSameSlot_thenNeitherIsSpread() {
+        CarbonIntensityDataFetcher sharedFetcher = mock(CarbonIntensityDataFetcher.class);
+        CarbonIntensityJsonParser parser = new CarbonIntensityJsonParser();
+        var carbonIntensity = parser.parse(ClassLoader.getSystemResourceAsStream("day-ahead-20240824-Z.json"));
+        // Same fixture regardless of zone is fine here: what matters is that both jobs independently
+        // resolve to the same greenest instant, and neither gets bumped because of the other's zone.
+        when(sharedFetcher.fetchCarbonIntensity(any())).thenReturn(carbonIntensity);
+
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+        CarbonIntensityPlanner<FixedWindowPlanningConstraints> plannerA = new FixedWindowPlanner(sharedFetcher, tracker, 1);
+        CarbonIntensityPlanner<FixedWindowPlanningConstraints> plannerB = new FixedWindowPlanner(sharedFetcher, tracker, 1);
+
+        ZonedDateTime ws = ZonedDateTime.parse("2024-08-27T00:00:00Z");
+        ZonedDateTime we = ws.plusHours(6);
+        var constraintsA = constraintsFor("job-a", "NL", ws, we);
+        var constraintsB = constraintsFor("job-b", "DE", ws, we);
+
+        ZonedDateTime timeA = plannerA.getNextExecutionTime(constraintsA);
+        ZonedDateTime timeB = plannerB.getNextExecutionTime(constraintsB);
+
+        assertThat(timeA).isNotNull();
+        assertThat(timeB).isNotNull();
+        // Different zones never compete for the same slot count: job-b lands on the exact same
+        // instant as job-a instead of being spread to the next-best slot.
+        assertThat(timeB).isEqualTo(timeA);
     }
 
     @Test

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/spi/TestConcurrencySlotTracker.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/spi/TestConcurrencySlotTracker.java
@@ -44,6 +44,25 @@ class TestConcurrencySlotTracker {
     }
 
     @Test
+    void twoZonesCanIndependentlyReserveTheExactSameInstant() {
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+
+        // Two jobs in different zones both want the exact same instant. Neither should see the
+        // other's reservation: coordination is per zone, never global.
+        tracker.reserve(ZONE_A, "job-a1", SLOT);
+        tracker.reserve(ZONE_B, "job-b1", SLOT);
+
+        // Each was the first (and only) reservation in its own zone, so each sees zero competitors
+        // at that instant - i.e. neither would be bumped to a later slot.
+        assertThat(tracker.countOthersAt(ZONE_A, "job-a1", SLOT)).isZero();
+        assertThat(tracker.countOthersAt(ZONE_B, "job-b1", SLOT)).isZero();
+
+        // A second job arriving in either zone only competes with reservations in that same zone.
+        assertThat(tracker.countOthersAt(ZONE_A, "job-a2", SLOT)).isEqualTo(1);
+        assertThat(tracker.countOthersAt(ZONE_B, "job-b2", SLOT)).isEqualTo(1);
+    }
+
+    @Test
     void countOthersAtIsZeroForAnUnreservedSlot() {
         ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
 

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/spi/TestConcurrencySlotTracker.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/spi/TestConcurrencySlotTracker.java
@@ -3,6 +3,15 @@ package io.carbonintensity.executionplanner.spi;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
 
@@ -67,5 +76,41 @@ class TestConcurrencySlotTracker {
         ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
 
         assertThat(tracker.countOthersAt(ZONE_A, "job-1", SLOT)).isZero();
+    }
+
+    @Test
+    void whenManyThreadsRaceForTheSameSlot_thenExactlyTheLimitSucceeds() throws Exception {
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+        int threadCount = 20;
+        int maxConcurrentPerSlot = 3;
+
+        // All threads call tryReserve for the same zone/slot at (as close to) the exact same moment,
+        // via a barrier - this is the scenario countOthersAt-then-reserve as two separate calls would
+        // race on: every thread could observe "under the limit" before any of them reserves.
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        try {
+            List<Callable<Boolean>> racers = IntStream.range(0, threadCount)
+                    .<Callable<Boolean>> mapToObj(i -> () -> {
+                        barrier.await();
+                        return tracker.tryReserve(ZONE_A, "job-" + i, SLOT, maxConcurrentPerSlot);
+                    })
+                    .collect(Collectors.toList());
+
+            List<Future<Boolean>> results = executor.invokeAll(racers);
+            long successes = results.stream().map(f -> {
+                try {
+                    return f.get();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }).filter(Boolean::booleanValue).count();
+
+            assertThat(successes).isEqualTo(maxConcurrentPerSlot);
+            assertThat(tracker.countOthersAt(ZONE_A, "some-other-job", SLOT)).isEqualTo(maxConcurrentPerSlot);
+        } finally {
+            executor.shutdown();
+            executor.awaitTermination(5, TimeUnit.SECONDS);
+        }
     }
 }


### PR DESCRIPTION
## What

`FixedWindowPlanner` and `SuccessivePlanner` both did `countOthersAt(...)` followed by `reserve(...)` as two separate calls, with nothing in between - a check-then-act race. Two concurrent callers targeting the same zone/slot could each observe "under the limit" and both reserve, silently exceeding `maxConcurrentPerSlot`.

This surfaced during a compatibility/architecture review of #235, #258 and #260 (not a bug report from production). The race is harmless today only because trigger evaluation happens to run on a single thread (`SimpleScheduler.checkTriggers()` via a single `scheduleAtFixedRate` task) - an assumption about the *caller*, not a property of `ConcurrencySlotTracker` itself. It was undocumented and untested, so a future refactor of the scheduling loop could silently break it. See `docs/adr/0002-spread-concurrent-scheduled-jobs.md` for the feature's design context.

## How

- New `tryReserve(zone, jobIdentity, slotStart, maxConcurrentPerSlot)` on `ConcurrencySlotTracker`, synchronized on a per-zone lock, doing the check and the reservation as one atomic operation. Returns `false` (no state change) if the limit is already reached.
- `reserve(...)` and `countOthersAt(...)` keep their exact existing signatures/semantics (the five existing tests are unchanged) but are now zone-lock-guarded too, for consistency with `tryReserve`.
- Both planners now call `tryReserve(...)` in their candidate loop instead of the two separate calls. The unconditional `reserve()` fallback path ("the job's own window always wins", ADR decision 5) is untouched - that's a deliberate limit override, not something `tryReserve` should gate.
- Per-zone locking preserves the existing zone-isolation guarantee: two zones never contend on the same lock.

## Tests

- First multithreaded test in the repo: `whenManyThreadsRaceForTheSameSlot_thenExactlyTheLimitSucceeds` fires 20 threads at the same zone/slot via a `CyclicBarrier`, asserts exactly `maxConcurrentPerSlot` (3) succeed and `countOthersAt` reports exactly 3 afterward. Verified non-flaky over 10 repeated runs.
- `mvn -pl execution-planner -am test`: 42/42 pass, including the 5 pre-existing `TestConcurrencySlotTracker` tests unchanged.
- `mvn -pl core,execution-planner,extensions/quarkus,extensions/spring-boot-starter -am test`: 42/42 pass, no regressions in either extension's property wiring.

## Checklist
- [x] Tests are added
- [x] Build runs successfully