### PR TITLE
Fix stale green-scheduler-bom:0.8.3 references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Maven:
 Gradle (Kotlin DSL):
 ```kotlin
 dependencies {
-    implementation(platform("io.carbonintensity:green-scheduler-bom:0.8.3"))
+    implementation(platform("io.carbonintensity:green-scheduler-bom:0.8.6"))
     implementation("io.carbonintensity:green-scheduler-micronaut")
 }
 ```
@@ -111,7 +111,7 @@ Maven:
 Gradle (Kotlin DSL):
 ```kotlin
 dependencies {
-    annotationProcessor(platform("io.carbonintensity:green-scheduler-bom:0.8.3"))
+    annotationProcessor(platform("io.carbonintensity:green-scheduler-bom:0.8.6"))
     annotationProcessor("io.carbonintensity:green-scheduler-micronaut-processor")
 }
 ```


### PR DESCRIPTION
The v0.8.6 release bump (#269) covered the XML `<version>` tags but missed these two Gradle Kotlin-DSL string-literal references (`"io.carbonintensity:green-scheduler-bom:0.8.3"`) in the Micronaut usage section, added by #211. Found while working on green-scheduler#241.