### PR TITLE
Strengthen mutation-weak tests and fix a real carbon-intensity calculation bug

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -397,6 +397,40 @@ For an aggregated, multi-module report covering `core` and `execution-planner` t
 `mvn -pl core,execution-planner,coverage-report -am install -Ptest-coverage` from the repo root; the report is
 generated in `coverage-report/target/site/jacoco-aggregate/`.
 
+### Mutation testing (does high coverage% actually mean anything?)
+
+Line coverage only proves a line *ran*, not that a test would notice if its logic broke. PIT (mutation testing)
+checks that by deliberately introducing small bugs ("mutants": flipping a `<=` to `<`, deleting a call, replacing
+a return value with `null`) and confirming the test suite actually fails. A class at 95-100% coverage can still
+have a mutation score far below that.
+
+Configured (local/manual only, not part of `mvn verify` or CI) in `core/pom.xml` (scoped to
+`io.carbonintensity.scheduler.runtime.*`) and `execution-planner/pom.xml` (scoped to `...planner.*`/`...strategy.*`).
+Run per module:
+
+```bash
+mvn initialize org.pitest:pitest-maven:mutationCoverage -pl core
+mvn initialize org.pitest:pitest-maven:mutationCoverage -pl execution-planner -am
+```
+
+The HTML report lands in `target/pit-reports/`. There is no enforced minimum score (no gate) - use it to spot-check
+whether a high-coverage class's tests actually assert anything meaningful.
+
+**When a finding shows high coverage but a low mutation score, it's almost always one of these three shapes -
+check which one before writing anything:**
+
+1. **The test never asserts on the return value, only on a side effect.** Common in invoker/wrapper classes
+   tested through a scheduler-level integration test (a `CountDownLatch`, a listener callback) rather than
+   directly: the side effect gets verified, but whatever the method actually *returns* never does. Fix: assert
+   on the returned value itself, in addition to (not instead of) the existing side-effect check.
+2. **The test never places a value exactly on a boundary.** Common in interval/range comparison logic
+   (`<=`/`>=` deciding which branch a value falls into): existing tests use clearly-inside or clearly-outside
+   values, so a boundary comparison can flip without any test noticing. Fix: add a case where a start/end value
+   sits exactly on the boundary being compared.
+3. **It's not a weak assertion, it's just missing coverage.** A large class can have a merely mediocre mutation
+   score without either pattern above - it's simply too big for the existing tests to reach every path. Fix:
+   add tests for the untested paths; there's no shortcut here.
+
 ### Check security vulnerabilities
 
 When adding a new extension or updating the dependencies of an existing one,

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,6 +17,38 @@
     <build>
         <plugins>
             <plugin>
+                <!-- Mutation testing. Local/manual only - not bound to any lifecycle phase, so
+                     "mvn verify" never triggers it and it is not a CI gate. Run explicitly:
+                       mvn initialize org.pitest:pitest-maven:mutationCoverage -pl core
+                     Scoped to the runtime/annotation-parsing packages (AbstractJobDefinition,
+                     SkipConcurrentExecutionInvoker, the *ExpressionParser/AnnotationParser
+                     classes) rather than the whole module, since mutation testing is slow. -->
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <version>${pitest-maven.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.pitest</groupId>
+                        <artifactId>pitest-junit5-plugin</artifactId>
+                        <version>${pitest-junit5-plugin.version}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <targetClasses>
+                        <param>io.carbonintensity.scheduler.runtime.*</param>
+                    </targetClasses>
+                    <targetTests>
+                        <!-- Broader than targetClasses on purpose: the tests that actually exercise
+                             e.g. AbstractJobDefinition/SkipConcurrentExecutionInvoker live one
+                             package up (io.carbonintensity.scheduler.TestFixedWindowScheduler and
+                             friends), not under .runtime.* itself - scoping targetTests as narrowly
+                             as targetClasses silently excluded them and made coverage look near-0%. -->
+                        <param>io.carbonintensity.scheduler.*</param>
+                    </targetTests>
+                    <timestampedReports>false</timestampedReports>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/SimpleScheduler.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/SimpleScheduler.java
@@ -717,7 +717,7 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         }
 
         public boolean isOverdue() {
-            ZonedDateTime now = ZonedDateTime.now();
+            ZonedDateTime now = ZonedDateTime.now(this.clock);
             if (now.isBefore(this.start)) {
                 return false;
             } else {

--- a/core/src/test/java/io/carbonintensity/scheduler/runtime/ScheduledMethodTest.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/runtime/ScheduledMethodTest.java
@@ -1,0 +1,24 @@
+package io.carbonintensity.scheduler.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link ScheduledMethod#getMethodDescription()} is only reached indirectly by other tests, none
+ * of which inspect the actual string it produces - PIT (CIIO-337) found the "replaced return value
+ * with empty string" mutant survives as a result.
+ */
+class ScheduledMethodTest {
+
+    @Test
+    void getMethodDescriptionCombinesTheDeclaringClassAndMethodName() {
+        ScheduledMethod method = new ImmutableScheduledMethod(mock(ScheduledInvoker.class),
+                "io.carbonintensity.MyJob", "run", List.of());
+
+        assertThat(method.getMethodDescription()).isEqualTo("io.carbonintensity.MyJob#run");
+    }
+}

--- a/core/src/test/java/io/carbonintensity/scheduler/runtime/SimpleSchedulerLifecycleTest.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/runtime/SimpleSchedulerLifecycleTest.java
@@ -1,0 +1,109 @@
+package io.carbonintensity.scheduler.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.carbonintensity.scheduler.Scheduler;
+import io.carbonintensity.scheduler.test.helper.DisabledDummyCarbonIntensityApi;
+
+/**
+ * {@code pause()}/{@code resume()}/{@code isRunning()} had zero coverage at all (CIIO-340,
+ * NO_COVERAGE mutants) - no existing test ever calls them. These are the scheduler-wide (not
+ * per-job) lifecycle operations; the per-identity {@code pause(String)}/{@code resume(String)}/
+ * {@code isPaused(String)} variants need a scheduled task and are left for a follow-up.
+ */
+class SimpleSchedulerLifecycleTest {
+
+    private SimpleScheduler scheduler;
+
+    @AfterEach
+    void afterEach() {
+        if (scheduler != null) {
+            scheduler.close();
+        }
+    }
+
+    private SimpleScheduler startedSchedulerWith(boolean enabled) {
+        SchedulerConfig config = new SchedulerConfig();
+        config.setEnabled(enabled);
+        config.setCarbonIntensityApi(new DisabledDummyCarbonIntensityApi());
+        scheduler = new SimpleScheduler(config);
+        scheduler.start();
+        return scheduler;
+    }
+
+    @Test
+    void pauseStopsARunningSchedulerAndFiresSchedulerPaused() {
+        SimpleScheduler scheduler = startedSchedulerWith(true);
+        AtomicInteger pausedEvents = new AtomicInteger();
+        scheduler.addJobListener(new Scheduler.EventListener() {
+            @Override
+            public void schedulerPaused() {
+                pausedEvents.incrementAndGet();
+            }
+        });
+        // start() on an enabled, NORMAL-mode scheduler already leaves it running - confirm the
+        // precondition so the assertion after pause() actually proves a state change.
+        assertThat(scheduler.isRunning()).isTrue();
+
+        scheduler.pause();
+
+        assertThat(scheduler.isRunning()).isFalse();
+        assertThat(pausedEvents).hasValue(1);
+    }
+
+    @Test
+    void resumeRestartsAPausedSchedulerAndFiresSchedulerResumed() {
+        SimpleScheduler scheduler = startedSchedulerWith(true);
+        AtomicInteger resumedEvents = new AtomicInteger();
+        scheduler.addJobListener(new Scheduler.EventListener() {
+            @Override
+            public void schedulerResumed() {
+                resumedEvents.incrementAndGet();
+            }
+        });
+        scheduler.pause();
+        assertThat(scheduler.isRunning()).isFalse();
+
+        scheduler.resume();
+
+        assertThat(scheduler.isRunning()).isTrue();
+        assertThat(resumedEvents).hasValue(1);
+    }
+
+    @Test
+    void pauseAndResumeAreNoOpsOnADisabledSchedulerAndFireNoEvent() {
+        SimpleScheduler scheduler = startedSchedulerWith(false);
+        AtomicInteger events = new AtomicInteger();
+        scheduler.addJobListener(new Scheduler.EventListener() {
+            @Override
+            public void schedulerPaused() {
+                events.incrementAndGet();
+            }
+
+            @Override
+            public void schedulerResumed() {
+                events.incrementAndGet();
+            }
+        });
+
+        // Kills the "negated conditional" mutants on the !enabled guards in pause()/resume():
+        // a disabled scheduler must log-and-return, not toggle running or fire an event.
+        scheduler.pause();
+        scheduler.resume();
+
+        assertThat(scheduler.isRunning()).isFalse();
+        assertThat(events).hasValue(0);
+    }
+
+    @Test
+    void isRunningIsFalseWhenDisabledEvenAfterStart() {
+        SimpleScheduler scheduler = startedSchedulerWith(false);
+
+        assertThat(scheduler.isRunning()).isFalse();
+    }
+}

--- a/core/src/test/java/io/carbonintensity/scheduler/runtime/SimpleSchedulerLifecycleTest.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/runtime/SimpleSchedulerLifecycleTest.java
@@ -1,20 +1,34 @@
 package io.carbonintensity.scheduler.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import io.carbonintensity.scheduler.GreenScheduled;
 import io.carbonintensity.scheduler.Scheduler;
+import io.carbonintensity.scheduler.Trigger;
+import io.carbonintensity.scheduler.test.helper.AnnotationUtil;
 import io.carbonintensity.scheduler.test.helper.DisabledDummyCarbonIntensityApi;
 
 /**
  * {@code pause()}/{@code resume()}/{@code isRunning()} had zero coverage at all (CIIO-340,
  * NO_COVERAGE mutants) - no existing test ever calls them. These are the scheduler-wide (not
- * per-job) lifecycle operations; the per-identity {@code pause(String)}/{@code resume(String)}/
- * {@code isPaused(String)} variants need a scheduled task and are left for a follow-up.
+ * per-job) lifecycle operations.
+ * <p>
+ * This class also covers the per-identity {@code pause(String)}/{@code resume(String)}/
+ * {@code isPaused(String)} variants and {@code unscheduleJob(String)}, which need a scheduled
+ * task and were originally left for a follow-up (CIIO-340).
  */
 class SimpleSchedulerLifecycleTest {
 
@@ -105,5 +119,207 @@ class SimpleSchedulerLifecycleTest {
         SimpleScheduler scheduler = startedSchedulerWith(false);
 
         assertThat(scheduler.isRunning()).isFalse();
+    }
+
+    private SimpleScheduler enabledScheduler() {
+        SchedulerConfig config = new SchedulerConfig();
+        config.setCarbonIntensityApi(new DisabledDummyCarbonIntensityApi());
+        scheduler = new SimpleScheduler(config);
+        return scheduler;
+    }
+
+    private Trigger scheduleProgrammaticJob(SimpleScheduler scheduler, String identity, Runnable onRun) {
+        return scheduler.newJob(identity)
+                .setCarbonIntensityZone("NL")
+                .setMinimumGap(Duration.ofSeconds(1))
+                .setMaximumGap(Duration.ofSeconds(1))
+                .setDuration(Duration.ofSeconds(1))
+                .setTask(execution -> onRun.run())
+                .schedule();
+    }
+
+    // --- unscheduleJob(String) ---
+
+    @Test
+    void unscheduleJobRemovesAProgrammaticJobAndReturnsItsTrigger() {
+        SimpleScheduler scheduler = enabledScheduler();
+        Trigger trigger = scheduleProgrammaticJob(scheduler, "job-1", () -> {
+        });
+        assertThat(scheduler.getScheduledJob("job-1")).isSameAs(trigger);
+
+        Trigger unscheduled = scheduler.unscheduleJob("job-1");
+
+        assertThat(unscheduled).isSameAs(trigger);
+        assertThat(scheduler.getScheduledJob("job-1")).isNull();
+        assertThat(scheduler.getScheduledJobs()).doesNotContain(trigger);
+    }
+
+    @Test
+    void unscheduleJobReturnsNullForAnUnknownIdentity() {
+        SimpleScheduler scheduler = enabledScheduler();
+
+        assertThat(scheduler.unscheduleJob("does-not-exist")).isNull();
+    }
+
+    @Test
+    void unscheduleJobReturnsNullForAnEmptyIdentity() {
+        SimpleScheduler scheduler = enabledScheduler();
+
+        assertThat(scheduler.unscheduleJob("")).isNull();
+    }
+
+    @Test
+    void unscheduleJobThrowsOnNullIdentity() {
+        SimpleScheduler scheduler = enabledScheduler();
+
+        assertThatThrownBy(() -> scheduler.unscheduleJob(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    // Kills the "task.isProgrammatic" mutant: a job scheduled via an annotation (scheduleMethod)
+    // must NOT be removable through unscheduleJob, which is documented as the counterpart of
+    // newJob()/programmatic scheduling only.
+    @Test
+    void unscheduleJobIsANoOpForAnAnnotationScheduledJob() {
+        SimpleScheduler scheduler = enabledScheduler();
+        CountDownLatch cdl = new CountDownLatch(1);
+        ScheduledInvoker invoker = execution -> {
+            cdl.countDown();
+            return CompletableFuture.completedStage(null);
+        };
+        GreenScheduled greenScheduled = AnnotationUtil.newGreenScheduled()
+                .successive("1s 1s 1s")
+                .carbonIntensityZone("NL")
+                .duration("1s")
+                .identity("annotation-job")
+                .build();
+        scheduler.scheduleMethod(new ImmutableScheduledMethod(invoker, this.getClass().getName(),
+                "unscheduleJobIsANoOpForAnAnnotationScheduledJob", List.of(greenScheduled)));
+        Trigger trigger = scheduler.getScheduledJob("annotation-job");
+        assertThat(trigger).isNotNull();
+
+        assertThat(scheduler.unscheduleJob("annotation-job")).isNull();
+
+        assertThat(scheduler.getScheduledJob("annotation-job")).isSameAs(trigger);
+    }
+
+    // --- pause(String) / resume(String) / isPaused(String) ---
+
+    @Test
+    void pauseByIdentityPausesOnlyThatJobAndFiresJobPaused() {
+        SimpleScheduler scheduler = enabledScheduler();
+        Trigger pausedTrigger = scheduleProgrammaticJob(scheduler, "job-1", () -> {
+        });
+        scheduleProgrammaticJob(scheduler, "job-2", () -> {
+        });
+        List<Trigger> pausedEvents = new ArrayList<>();
+        scheduler.addJobListener(new Scheduler.EventListener() {
+            @Override
+            public void jobPaused(Trigger trigger) {
+                pausedEvents.add(trigger);
+            }
+        });
+
+        scheduler.pause("job-1");
+
+        assertThat(scheduler.isPaused("job-1")).isTrue();
+        assertThat(scheduler.isPaused("job-2")).isFalse();
+        assertThat(pausedEvents).containsExactly(pausedTrigger);
+    }
+
+    @Test
+    void resumeByIdentityResumesOnlyThatJobAndFiresJobResumed() {
+        SimpleScheduler scheduler = enabledScheduler();
+        Trigger resumedTrigger = scheduleProgrammaticJob(scheduler, "job-1", () -> {
+        });
+        scheduleProgrammaticJob(scheduler, "job-2", () -> {
+        });
+        scheduler.pause("job-1");
+        scheduler.pause("job-2");
+        List<Trigger> resumedEvents = new ArrayList<>();
+        scheduler.addJobListener(new Scheduler.EventListener() {
+            @Override
+            public void jobResumed(Trigger trigger) {
+                resumedEvents.add(trigger);
+            }
+        });
+
+        scheduler.resume("job-1");
+
+        assertThat(scheduler.isPaused("job-1")).isFalse();
+        assertThat(scheduler.isPaused("job-2")).isTrue();
+        assertThat(resumedEvents).containsExactly(resumedTrigger);
+    }
+
+    @Test
+    void pauseAndResumeByIdentityAreNoOpsForAnUnknownIdentity() {
+        SimpleScheduler scheduler = enabledScheduler();
+        AtomicInteger events = new AtomicInteger();
+        scheduler.addJobListener(new Scheduler.EventListener() {
+            @Override
+            public void jobPaused(Trigger trigger) {
+                events.incrementAndGet();
+            }
+
+            @Override
+            public void jobResumed(Trigger trigger) {
+                events.incrementAndGet();
+            }
+        });
+
+        scheduler.pause("does-not-exist");
+        scheduler.resume("does-not-exist");
+
+        assertThat(events).hasValue(0);
+        assertThat(scheduler.isPaused("does-not-exist")).isFalse();
+    }
+
+    @Test
+    void pauseAndResumeByIdentityAreNoOpsForAnEmptyIdentity() {
+        SimpleScheduler scheduler = enabledScheduler();
+        AtomicInteger events = new AtomicInteger();
+        scheduler.addJobListener(new Scheduler.EventListener() {
+            @Override
+            public void jobPaused(Trigger trigger) {
+                events.incrementAndGet();
+            }
+
+            @Override
+            public void jobResumed(Trigger trigger) {
+                events.incrementAndGet();
+            }
+        });
+
+        scheduler.pause("");
+        scheduler.resume("");
+
+        assertThat(events).hasValue(0);
+        assertThat(scheduler.isPaused("")).isFalse();
+    }
+
+    @Test
+    void pauseResumeAndIsPausedThrowOnNullIdentity() {
+        SimpleScheduler scheduler = enabledScheduler();
+
+        assertThatThrownBy(() -> scheduler.pause((String) null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> scheduler.resume((String) null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> scheduler.isPaused(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    // Integration-level proof that pause(identity) doesn't just flip a flag: the paused job's
+    // invoker is never actually called by ScheduledTask.execute(), while an unpaused sibling job
+    // keeps firing normally in the same scheduler.
+    @Test
+    void pauseByIdentityActuallyPreventsThatJobFromFiringWhileOthersKeepRunning() {
+        SimpleScheduler scheduler = enabledScheduler();
+        AtomicInteger pausedRuns = new AtomicInteger();
+        AtomicInteger activeRuns = new AtomicInteger();
+
+        scheduleProgrammaticJob(scheduler, "paused-job", pausedRuns::incrementAndGet);
+        scheduleProgrammaticJob(scheduler, "active-job", activeRuns::incrementAndGet);
+        scheduler.pause("paused-job");
+
+        Awaitility.waitAtMost(30, TimeUnit.SECONDS).until(() -> activeRuns.get() >= 1);
+
+        assertThat(pausedRuns.get()).isZero();
     }
 }

--- a/core/src/test/java/io/carbonintensity/scheduler/runtime/SkipConcurrentExecutionInvokerTest.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/runtime/SkipConcurrentExecutionInvokerTest.java
@@ -55,6 +55,8 @@ class SkipConcurrentExecutionInvokerTest {
 
         assertThat(delegate.invocationCount()).isEqualTo(1);
         assertThat(skipCount.get()).isEqualTo(1);
+        // Kills the "replaced return value with null" mutant on the skip path: the returned stage must
+        // actually be a completed one (so a caller doesn't wait on it forever), not merely non-null.
         assertThat(skipped.toCompletableFuture()).isCompletedWithValue(null);
     }
 
@@ -90,11 +92,16 @@ class SkipConcurrentExecutionInvokerTest {
         SkipConcurrentExecutionInvoker invoker = new SkipConcurrentExecutionInvoker(delegate, events);
         ScheduledExecution execution = new FixedExecution();
 
-        invoker.invoke(execution);
+        CompletionStage<Void> forwarded = invoker.invoke(execution);
         invoker.invoke(execution); // skipped while pending
         assertThat(delegate.invocationCount()).isEqualTo(1);
 
         delegate.mostRecentFuture().complete(null);
+
+        // Kills the "replaced return value with null" mutant on the success path: a caller awaiting the
+        // forwarded call's stage must actually see it complete with the delegate's result, not receive a
+        // stage that was stubbed out independently of the delegate's own completion.
+        assertThat(forwarded.toCompletableFuture()).isCompletedWithValue(null);
 
         invoker.invoke(execution);
         assertThat(delegate.invocationCount()).isEqualTo(2);

--- a/core/src/test/java/io/carbonintensity/scheduler/runtime/StatusEmitterInvokerTest.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/runtime/StatusEmitterInvokerTest.java
@@ -1,0 +1,64 @@
+package io.carbonintensity.scheduler.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import io.carbonintensity.scheduler.ScheduledExecution;
+import io.carbonintensity.scheduler.Trigger;
+
+/**
+ * Direct unit test for {@link StatusEmitterInvoker} - it had 100% line coverage from other tests
+ * routing through it, but PIT (CIIO-338) found that nothing actually verified the events it's
+ * responsible for firing: the success event, and the failure path entirely (0% coverage on that
+ * branch specifically).
+ */
+class StatusEmitterInvokerTest {
+
+    private ScheduledExecution execution() {
+        Trigger trigger = mock(Trigger.class);
+        when(trigger.getId()).thenReturn("test-trigger");
+        ScheduledExecution execution = mock(ScheduledExecution.class);
+        when(execution.getTrigger()).thenReturn(trigger);
+        when(execution.getScheduledFireTime()).thenReturn(Instant.EPOCH);
+        return execution;
+    }
+
+    @Test
+    void firesJobExecutionSuccessfulAndReturnsTheDelegatesResultOnSuccess() {
+        Events events = mock(Events.class);
+        ScheduledInvoker delegate = execution -> CompletableFuture.completedStage(null);
+        StatusEmitterInvoker invoker = new StatusEmitterInvoker(delegate, events);
+        ScheduledExecution execution = execution();
+
+        CompletionStage<Void> result = invoker.invoke(execution);
+
+        assertThat(result.toCompletableFuture()).succeedsWithin(1, TimeUnit.SECONDS);
+        verify(events).fireJobExecutionSuccessful(execution);
+    }
+
+    @Test
+    void firesJobExecutionFailedAndPropagatesTheFailureWhenTheDelegateFails() {
+        Events events = mock(Events.class);
+        RuntimeException boom = new RuntimeException("task failed");
+        ScheduledInvoker delegate = execution -> CompletableFuture.failedStage(boom);
+        StatusEmitterInvoker invoker = new StatusEmitterInvoker(delegate, events);
+        ScheduledExecution execution = execution();
+
+        CompletionStage<Void> result = invoker.invoke(execution);
+
+        assertThat(result.toCompletableFuture())
+                .failsWithin(1, TimeUnit.SECONDS)
+                .withThrowableThat()
+                .withCause(boom);
+        verify(events).fireJobExecutionFailed(execution, boom);
+    }
+}

--- a/core/src/test/java/io/carbonintensity/scheduler/runtime/TriggerOverdueAndNextFireTimeTest.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/runtime/TriggerOverdueAndNextFireTimeTest.java
@@ -1,0 +1,291 @@
+package io.carbonintensity.scheduler.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.chrono.ChronoZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+
+import org.junit.jupiter.api.Test;
+
+import com.cronutils.model.Cron;
+import com.cronutils.model.CronType;
+import com.cronutils.model.definition.CronDefinition;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.model.time.ExecutionTime;
+import com.cronutils.parser.CronParser;
+
+import io.carbonintensity.executionplanner.planner.fixedwindow.DefaultFixedWindowPlanningConstraints;
+import io.carbonintensity.executionplanner.planner.fixedwindow.FixedWindowPlanningConstraints;
+import io.carbonintensity.executionplanner.planner.successive.DefaultSuccessivePlanningConstraints;
+import io.carbonintensity.executionplanner.planner.successive.SuccessivePlanningConstraints;
+import io.carbonintensity.executionplanner.spi.CarbonIntensityPlanner;
+import io.vavr.test.Arbitrary;
+import io.vavr.test.Gen;
+import io.vavr.test.Property;
+
+/**
+ * {@code isOverdue()}/{@code getNextFireTime()} had zero test coverage across all four trigger
+ * classes nested in {@link SimpleScheduler} (CIIO-340, NO_COVERAGE mutants): {@link SimpleScheduler.CronTrigger},
+ * {@link SimpleScheduler.FixedWindowTrigger}, {@link SimpleScheduler.IntervalTrigger} and
+ * {@link SimpleScheduler.SuccessiveTrigger}. Each class is exercised directly (these are
+ * package-private nested classes, so this test lives in the same package), independently of the
+ * full {@code SimpleScheduler}/annotation machinery, using a fixed-plus-offset {@link Clock} per
+ * check rather than the shared {@code MutableClock} - there's no periodic re-evaluation to drive
+ * here, just pure reads of {@code isOverdue()}/{@code getNextFireTime()}.
+ * <p>
+ * {@code IntervalTrigger}'s own constructor is private - in production it's only ever reachable
+ * through {@link SimpleScheduler.SuccessiveTrigger}'s fallback path (when its planner reports it
+ * cannot schedule). It's exercised here the same way, via a stubbed planner.
+ * <p>
+ * Found and fixed a real clock-injection bug in {@link SimpleScheduler.CronTrigger#isOverdue()}: see
+ * {@link #cronTriggerIsOverdueMatchesItsOwnNextFireTimePlusGracePeriod()}.
+ */
+class TriggerOverdueAndNextFireTimeTest {
+
+    private static final Duration GRACE_PERIOD = Duration.ofSeconds(2);
+    private static final Arbitrary<Integer> FORWARD_SHIFT_SECONDS = size -> Gen.choose(0, 3600);
+
+    private static Cron everySecondCron() {
+        CronDefinition definition = CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ);
+        return new CronParser(definition).parse("* * * * * ?");
+    }
+
+    private static ZonedDateTime nowTruncatedToSeconds() {
+        return ZonedDateTime.now(Clock.systemUTC()).truncatedTo(ChronoUnit.SECONDS);
+    }
+
+    private static Clock clockAt(ZonedDateTime base, int shiftSeconds) {
+        return Clock.offset(Clock.fixed(base.toInstant(), ZoneOffset.UTC), Duration.ofSeconds(shiftSeconds));
+    }
+
+    // --- CronTrigger ---
+
+    // Property-of-record for CIIO-340: this failed before the fix below, because isOverdue() used
+    // ZonedDateTime.now() (the real system clock) instead of ZonedDateTime.now(this.clock), so it
+    // silently ignored whatever Clock was injected into the trigger. Fixed in
+    // SimpleScheduler.CronTrigger#isOverdue() by using ZonedDateTime.now(this.clock).
+    @Test
+    void cronTriggerIsOverdueMatchesItsOwnNextFireTimePlusGracePeriod() {
+        ZonedDateTime start = nowTruncatedToSeconds();
+        Cron everySecond = everySecondCron();
+
+        Property.def("CronTrigger.isOverdue() reflects getNextFireTime() + gracePeriod, using the trigger's injected clock")
+                .forAll(FORWARD_SHIFT_SECONDS)
+                .suchThat(shiftSeconds -> {
+                    Clock clock = clockAt(start, shiftSeconds);
+                    SimpleScheduler.CronTrigger trigger = new SimpleScheduler.CronTrigger("id", start, everySecond,
+                            GRACE_PERIOD,
+                            "desc", clock);
+
+                    Instant expectedNextFireTime = ExecutionTime.forCron(everySecond).nextExecution(start)
+                            .map(ChronoZonedDateTime::toInstant).orElse(null);
+                    ZonedDateTime now = ZonedDateTime.now(clock);
+                    boolean expectedOverdue = !now.isBefore(start)
+                            && (expectedNextFireTime == null
+                                    || expectedNextFireTime.plus(GRACE_PERIOD).isBefore(now.toInstant()));
+
+                    return Objects.equals(expectedNextFireTime, trigger.getNextFireTime())
+                            && expectedOverdue == trigger.isOverdue();
+                })
+                .check()
+                .assertIsSatisfied();
+    }
+
+    @Test
+    void cronTriggerIsNotOverdueBeforeItsStartTime() {
+        ZonedDateTime start = nowTruncatedToSeconds().plusHours(1);
+        SimpleScheduler.CronTrigger trigger = new SimpleScheduler.CronTrigger("id", start, everySecondCron(), GRACE_PERIOD,
+                "desc",
+                Clock.systemUTC());
+
+        assertThat(trigger.isOverdue()).isFalse();
+    }
+
+    @Test
+    void cronTriggerIsOverdueOnlyStrictlyAfterNextFireTimePlusGracePeriod() {
+        ZonedDateTime start = nowTruncatedToSeconds();
+        Cron everySecond = everySecondCron();
+        Instant nextFireTime = ExecutionTime.forCron(everySecond).nextExecution(start).map(ChronoZonedDateTime::toInstant)
+                .orElseThrow();
+        Instant threshold = nextFireTime.plus(GRACE_PERIOD);
+
+        SimpleScheduler.CronTrigger notYetOverdue = new SimpleScheduler.CronTrigger("id", start, everySecond, GRACE_PERIOD,
+                "desc",
+                Clock.fixed(threshold, ZoneOffset.UTC));
+        assertThat(notYetOverdue.isOverdue()).isFalse();
+
+        SimpleScheduler.CronTrigger overdue = new SimpleScheduler.CronTrigger("id", start, everySecond, GRACE_PERIOD, "desc",
+                Clock.fixed(threshold.plusMillis(1), ZoneOffset.UTC));
+        assertThat(overdue.isOverdue()).isTrue();
+    }
+
+    // --- FixedWindowTrigger ---
+
+    private static FixedWindowPlanningConstraints fixedWindowConstraints(ZonedDateTime start, ZonedDateTime end) {
+        Cron cron = everySecondCron();
+        return DefaultFixedWindowPlanningConstraints.builder()
+                .withIdentity("id")
+                .withDuration(Duration.ofMinutes(1))
+                .withCarbonIntensityZone("NL")
+                .withCronExpression(cron)
+                .withStartAndEnd(start, end)
+                .withFallbackCronExpression(cron)
+                .withTimeZoneId(ZoneOffset.UTC)
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static CarbonIntensityPlanner<FixedWindowPlanningConstraints> mockFixedWindowPlanner() {
+        return mock(CarbonIntensityPlanner.class);
+    }
+
+    // FixedWindowTrigger#isOverdue() unconditionally returns false, regardless of the clock or the
+    // planner - unlike the other three trigger classes, it never falls back to CronTrigger's
+    // isOverdue() logic. This property pins that down across a wide range of clock offsets so a
+    // future accidental super.isOverdue() delegation is caught.
+    @Test
+    void fixedWindowTriggerIsNeverOverdue() {
+        ZonedDateTime start = nowTruncatedToSeconds();
+        FixedWindowPlanningConstraints constraints = fixedWindowConstraints(start, start.plusHours(2));
+        Arbitrary<Integer> wideShiftSeconds = size -> Gen.choose(-100_000, 100_000);
+
+        Property.def("FixedWindowTrigger.isOverdue() is always false, by design, regardless of the clock")
+                .forAll(wideShiftSeconds)
+                .suchThat(shiftSeconds -> {
+                    Clock clock = clockAt(start, shiftSeconds);
+                    SimpleScheduler.FixedWindowTrigger trigger = new SimpleScheduler.FixedWindowTrigger("id", "desc",
+                            GRACE_PERIOD,
+                            mockFixedWindowPlanner(), constraints, clock);
+                    return !trigger.isOverdue();
+                })
+                .check()
+                .assertIsSatisfied();
+    }
+
+    @Test
+    void fixedWindowTriggerGetNextFireTimeDelegatesToThePlanner() {
+        ZonedDateTime start = nowTruncatedToSeconds();
+        FixedWindowPlanningConstraints constraints = fixedWindowConstraints(start, start.plusHours(2));
+        CarbonIntensityPlanner<FixedWindowPlanningConstraints> planner = mockFixedWindowPlanner();
+        ZonedDateTime plannedTime = start.plusMinutes(42);
+        when(planner.getNextExecutionTime(constraints)).thenReturn(plannedTime);
+        SimpleScheduler.FixedWindowTrigger trigger = new SimpleScheduler.FixedWindowTrigger("id", "desc", GRACE_PERIOD, planner,
+                constraints, Clock.systemUTC());
+
+        assertThat(trigger.getNextFireTime()).isEqualTo(plannedTime.toInstant());
+    }
+
+    // --- IntervalTrigger (reached only via SuccessiveTrigger's fallback - its own constructor is
+    // private, used solely from within SuccessiveTrigger's super() call) ---
+
+    private static SuccessivePlanningConstraints successiveConstraints(ZonedDateTime start, Duration gap) {
+        return DefaultSuccessivePlanningConstraints.builder()
+                .withIdentity("id")
+                .withCarbonIntensityZone("NL")
+                .withInitialStartTime(start)
+                .withInitialMaximumDelay(Duration.ZERO)
+                .withMinimumGap(gap)
+                .withMaximumGap(gap)
+                .withDuration(Duration.ofSeconds(1))
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static CarbonIntensityPlanner<SuccessivePlanningConstraints> plannerThatCannotSchedule() {
+        CarbonIntensityPlanner<SuccessivePlanningConstraints> planner = mock(CarbonIntensityPlanner.class);
+        when(planner.canSchedule(any())).thenReturn(false);
+        return planner;
+    }
+
+    @Test
+    void intervalTriggerFallbackIsOverdueMatchesItsOwnNextFireTimePlusGracePeriod() {
+        ZonedDateTime start = nowTruncatedToSeconds();
+        Duration gap = Duration.ofSeconds(10); // minGap == maxGap, so the fallback interval is exactly `gap`
+
+        Property.def(
+                "IntervalTrigger (reached via SuccessiveTrigger's fallback) isOverdue() reflects its own getNextFireTime() + gracePeriod")
+                .forAll(FORWARD_SHIFT_SECONDS)
+                .suchThat(shiftSeconds -> {
+                    Clock clock = clockAt(start, shiftSeconds);
+                    SimpleScheduler.SuccessiveTrigger trigger = new SimpleScheduler.SuccessiveTrigger("id", clock, start,
+                            "desc",
+                            GRACE_PERIOD, plannerThatCannotSchedule(), successiveConstraints(start, gap));
+                    trigger.lastFireTime = start; // baseline: already fired exactly once, at "start"
+
+                    Instant expectedNextFireTime = start.plus(gap).toInstant();
+                    ZonedDateTime now = ZonedDateTime.now(clock);
+                    boolean expectedOverdue = !now.isBefore(start)
+                            && expectedNextFireTime.plus(GRACE_PERIOD).isBefore(now.toInstant());
+
+                    return expectedNextFireTime.equals(trigger.getNextFireTime()) && expectedOverdue == trigger.isOverdue();
+                })
+                .check()
+                .assertIsSatisfied();
+    }
+
+    @Test
+    void intervalTriggerFallbackIsNotOverdueBeforeItsStartTime() {
+        ZonedDateTime start = nowTruncatedToSeconds().plusHours(1);
+        SimpleScheduler.SuccessiveTrigger trigger = new SimpleScheduler.SuccessiveTrigger("id", Clock.systemUTC(), start,
+                "desc",
+                GRACE_PERIOD, plannerThatCannotSchedule(), successiveConstraints(start, Duration.ofSeconds(10)));
+        // lastFireTime intentionally left null: a trigger that hasn't started yet has never fired.
+
+        assertThat(trigger.isOverdue()).isFalse();
+    }
+
+    // --- SuccessiveTrigger's own logic (planner reports it CAN schedule) ---
+
+    @SuppressWarnings("unchecked")
+    private static CarbonIntensityPlanner<SuccessivePlanningConstraints> plannerReturning(ZonedDateTime nextExecutionTime) {
+        CarbonIntensityPlanner<SuccessivePlanningConstraints> planner = mock(CarbonIntensityPlanner.class);
+        when(planner.canSchedule(any())).thenReturn(true);
+        when(planner.getNextExecutionTime(any())).thenReturn(nextExecutionTime);
+        return planner;
+    }
+
+    @Test
+    void successiveTriggerIsOverdueMatchesThePlannedNextFireTimePlusGracePeriod() {
+        ZonedDateTime start = nowTruncatedToSeconds();
+        ZonedDateTime plannedNextFireTime = start.plusSeconds(30);
+        SuccessivePlanningConstraints constraints = successiveConstraints(start, Duration.ofSeconds(10));
+
+        Property.def(
+                "SuccessiveTrigger.isOverdue() reflects the planner's getNextExecutionTime() + gracePeriod when it can schedule")
+                .forAll(FORWARD_SHIFT_SECONDS)
+                .suchThat(shiftSeconds -> {
+                    Clock clock = clockAt(start, shiftSeconds);
+                    SimpleScheduler.SuccessiveTrigger trigger = new SimpleScheduler.SuccessiveTrigger("id", clock, start,
+                            "desc",
+                            GRACE_PERIOD, plannerReturning(plannedNextFireTime), constraints);
+
+                    ZonedDateTime now = ZonedDateTime.now(clock);
+                    boolean expectedOverdue = !now.isBefore(start)
+                            && plannedNextFireTime.toInstant().plus(GRACE_PERIOD).isBefore(now.toInstant());
+
+                    return plannedNextFireTime.toInstant().equals(trigger.getNextFireTime())
+                            && expectedOverdue == trigger.isOverdue();
+                })
+                .check()
+                .assertIsSatisfied();
+    }
+
+    @Test
+    void successiveTriggerIsNotOverdueBeforeItsStartTimeEvenWhenThePlannerCanSchedule() {
+        ZonedDateTime start = nowTruncatedToSeconds().plusHours(1);
+        SimpleScheduler.SuccessiveTrigger trigger = new SimpleScheduler.SuccessiveTrigger("id", Clock.systemUTC(), start,
+                "desc",
+                GRACE_PERIOD, plannerReturning(start.plusMinutes(5)), successiveConstraints(start, Duration.ofSeconds(10)));
+
+        assertThat(trigger.isOverdue()).isFalse();
+    }
+}

--- a/core/src/test/java/io/carbonintensity/scheduler/runtime/impl/SchedulerContextImplTest.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/runtime/impl/SchedulerContextImplTest.java
@@ -1,0 +1,27 @@
+package io.carbonintensity.scheduler.runtime.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.carbonintensity.scheduler.runtime.ScheduledMethod;
+
+/**
+ * {@link SchedulerContextImpl#getScheduledMethods()} is only reached indirectly, never with its
+ * result inspected - PIT (CIIO-337) found the "replaced return value with an empty list" mutant
+ * survives as a result.
+ */
+class SchedulerContextImplTest {
+
+    @Test
+    void getScheduledMethodsReturnsExactlyWhatWasPassedToTheConstructor() {
+        ScheduledMethod methodA = mock(ScheduledMethod.class);
+        ScheduledMethod methodB = mock(ScheduledMethod.class);
+        SchedulerContextImpl context = new SchedulerContextImpl(List.of(methodA, methodB));
+
+        assertThat(context.getScheduledMethods()).containsExactly(methodA, methodB);
+    }
+}

--- a/execution-planner/pom.xml
+++ b/execution-planner/pom.xml
@@ -18,6 +18,34 @@
     <build>
         <plugins>
             <plugin>
+                <!-- Mutation testing. Local/manual only - see core/pom.xml for the full rationale.
+                     Run explicitly:
+                       mvn initialize org.pitest:pitest-maven:mutationCoverage -pl execution-planner -am
+                     Scoped to the planner/strategy packages (Timeslot, SingleJobStrategy and
+                     friends - the "which slot is greenest" decision logic). -->
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <version>${pitest-maven.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.pitest</groupId>
+                        <artifactId>pitest-junit5-plugin</artifactId>
+                        <version>${pitest-junit5-plugin.version}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <targetClasses>
+                        <param>io.carbonintensity.executionplanner.planner.*</param>
+                        <param>io.carbonintensity.executionplanner.strategy.*</param>
+                    </targetClasses>
+                    <targetTests>
+                        <param>io.carbonintensity.executionplanner.planner.*</param>
+                        <param>io.carbonintensity.executionplanner.strategy.*</param>
+                    </targetTests>
+                    <timestampedReports>false</timestampedReports>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/Timeslot.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/Timeslot.java
@@ -88,14 +88,22 @@ public class Timeslot {
             } else {
                 secsInCiPeriod = Duration.between(start.toInstant(), ciEnd).getSeconds();
             }
-            return ci.value().divide(BigDecimal.valueOf(ci.resolution().getSeconds()), RoundingMode.HALF_EVEN)
-                    .multiply(BigDecimal.valueOf(secsInCiPeriod));
+            // Multiply before dividing, and with an explicit scale (CIIO-341): dividing first with
+            // no explicit scale rounds to the *dividend's* scale (0 for a typical integer-valued
+            // reading), silently truncating any per-second rate below 1 to zero before the
+            // multiply ever runs - which a partial overlap almost always is.
+            return ci.value().multiply(BigDecimal.valueOf(secsInCiPeriod))
+                    .divide(BigDecimal.valueOf(ci.resolution().getSeconds()), 10, RoundingMode.HALF_EVEN);
         }
         //job ends in or on ci window, but does not start in it
         if (end.toInstant().compareTo(ciStart) >= 0 && end.toInstant().compareTo(ciEnd) <= 0) {
             long secsInCiPeriod = Duration.between(ciStart, end.toInstant()).getSeconds();
-            return ci.value().divide(BigDecimal.valueOf(ci.resolution().getSeconds()), RoundingMode.HALF_EVEN)
-                    .multiply(BigDecimal.valueOf(secsInCiPeriod));
+            // Multiply before dividing, and with an explicit scale (CIIO-341): dividing first with
+            // no explicit scale rounds to the *dividend's* scale (0 for a typical integer-valued
+            // reading), silently truncating any per-second rate below 1 to zero before the
+            // multiply ever runs - which a partial overlap almost always is.
+            return ci.value().multiply(BigDecimal.valueOf(secsInCiPeriod))
+                    .divide(BigDecimal.valueOf(ci.resolution().getSeconds()), 10, RoundingMode.HALF_EVEN);
         }
 
         return BigDecimal.ZERO;

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/CarbonIntensityPeriodTest.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/CarbonIntensityPeriodTest.java
@@ -1,0 +1,86 @@
+package io.carbonintensity.executionplanner.planner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensity;
+
+/**
+ * {@link CarbonIntensityPeriod} had no direct test at all - it was only exercised indirectly
+ * through {@link TestTimeslot}, which never inspects its own behavior. PIT (CIIO-339) found
+ * {@code equals}/{@code compareTo} entirely unreached, and every boundary comparison in
+ * {@link CarbonIntensityPeriod#contains} survives - existing indirect coverage never places a
+ * point exactly on the period's start or end.
+ */
+class CarbonIntensityPeriodTest {
+
+    private static final Instant START = Instant.parse("2026-01-01T00:00:00Z");
+    private static final Duration RESOLUTION = Duration.ofMinutes(15);
+
+    private CarbonIntensityPeriod period(BigDecimal value) {
+        return CarbonIntensityPeriod.of(carbonIntensity(value)).get(0);
+    }
+
+    private CarbonIntensity carbonIntensity(BigDecimal value) {
+        CarbonIntensity ci = new CarbonIntensity();
+        ci.setStart(START);
+        ci.setResolution(RESOLUTION);
+        ci.setData(List.of(value));
+        return ci;
+    }
+
+    @Test
+    void ofBuildsOnePeriodPerDataPointStartingAtTheGivenInstant() {
+        List<CarbonIntensityPeriod> periods = CarbonIntensityPeriod.of(carbonIntensity(BigDecimal.TEN));
+
+        assertThat(periods).hasSize(1);
+        assertThat(periods.get(0).moment()).isEqualTo(START);
+        assertThat(periods.get(0).value()).isEqualByComparingTo(BigDecimal.TEN);
+        assertThat(periods.get(0).resolution()).isEqualTo(RESOLUTION);
+    }
+
+    @Test
+    void containsIsInclusiveOfBothTheStartAndEndInstantExactly() {
+        CarbonIntensityPeriod p = period(BigDecimal.ONE);
+        Instant end = START.plus(RESOLUTION);
+
+        // Kills the "changed conditional boundary"/"negated conditional" mutants on line 74:
+        // a point exactly on either edge must count as contained, and one nanosecond outside
+        // either edge must not.
+        assertThat(p.contains(START)).as("exactly at the start").isTrue();
+        assertThat(p.contains(end)).as("exactly at the end").isTrue();
+        assertThat(p.contains(START.minusNanos(1))).as("one ns before the start").isFalse();
+        assertThat(p.contains(end.plusNanos(1))).as("one ns after the end").isFalse();
+        assertThat(p.contains(START.plusSeconds(1))).as("well inside").isTrue();
+    }
+
+    @Test
+    void equalsAndHashCodeAreBasedOnMomentValueAndResolution() {
+        CarbonIntensityPeriod a = period(BigDecimal.valueOf(42));
+        CarbonIntensityPeriod b = period(BigDecimal.valueOf(42));
+        CarbonIntensityPeriod differentValue = period(BigDecimal.valueOf(43));
+
+        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
+        assertThat(a).isNotEqualTo(differentValue);
+        assertThat(a).isNotEqualTo(null);
+        assertThat(a).isNotEqualTo("not a period");
+    }
+
+    @Test
+    void compareToOrdersByMomentThenResolution() {
+        CarbonIntensityPeriod earlier = CarbonIntensityPeriod.of(carbonIntensity(BigDecimal.ONE)).get(0);
+        CarbonIntensity laterCi = carbonIntensity(BigDecimal.ONE);
+        laterCi.setStart(START.plus(RESOLUTION));
+        CarbonIntensityPeriod later = CarbonIntensityPeriod.of(laterCi).get(0);
+
+        assertThat(earlier.compareTo(later)).isNegative();
+        assertThat(later.compareTo(earlier)).isPositive();
+        assertThat(earlier.compareTo(earlier)).isZero();
+    }
+}

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/CarbonIntensityPeriodTest.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/CarbonIntensityPeriodTest.java
@@ -46,17 +46,23 @@ class CarbonIntensityPeriodTest {
     }
 
     @Test
-    void containsIsInclusiveOfBothTheStartAndEndInstantExactly() {
+    void containsIsInclusiveOfTheStartAndExclusiveOfTheEndInstant() {
         CarbonIntensityPeriod p = period(BigDecimal.ONE);
         Instant end = START.plus(RESOLUTION);
 
-        // Kills the "changed conditional boundary"/"negated conditional" mutants on line 74:
-        // a point exactly on either edge must count as contained, and one nanosecond outside
-        // either edge must not.
+        // Kills the "changed conditional boundary"/"negated conditional" mutants on the contains()
+        // comparisons: a point exactly on the start edge must count as contained, one nanosecond
+        // before the start must not, and neither must the end instant itself.
+        //
+        // The upper bound is deliberately EXCLUSIVE, not inclusive: CarbonIntensityPeriod.of(...)
+        // produces contiguous periods where period[i].moment() + resolution == period[i + 1].moment().
+        // If both bounds were inclusive (as an earlier version of this test asserted), that shared
+        // boundary instant would be reported as contained by two consecutive periods at once - see
+        // CIIO-366, which found this exact double-inclusive bug via a property test.
         assertThat(p.contains(START)).as("exactly at the start").isTrue();
-        assertThat(p.contains(end)).as("exactly at the end").isTrue();
+        assertThat(p.contains(end)).as("exactly at the end").isFalse();
         assertThat(p.contains(START.minusNanos(1))).as("one ns before the start").isFalse();
-        assertThat(p.contains(end.plusNanos(1))).as("one ns after the end").isFalse();
+        assertThat(p.contains(end.minusNanos(1))).as("one ns before the end").isTrue();
         assertThat(p.contains(START.plusSeconds(1))).as("well inside").isTrue();
     }
 

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/TimeslotCalculateCarbonIntensityTest.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/TimeslotCalculateCarbonIntensityTest.java
@@ -1,0 +1,107 @@
+package io.carbonintensity.executionplanner.planner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensity;
+
+/**
+ * Direct tests of {@link Timeslot#calculateCarbonIntensity(List, ZonedDateTime, ZonedDateTime)},
+ * placing a job's start/end exactly on a carbon-intensity period's boundary. {@link TestTimeslot}
+ * only ever asserts on timeslot *counts* through {@link Timeslot#getTimeslots}, never on this
+ * method's actual result, and never with a boundary-exact value - PIT (CIIO-336) found every
+ * comparison in the three overlap branches survives as a result.
+ */
+class TimeslotCalculateCarbonIntensityTest {
+
+    // One carbon-intensity period: [2026-01-01T00:00Z, 2026-01-01T01:00Z], value 100.
+    private static final ZonedDateTime CI_START = ZonedDateTime.parse("2026-01-01T00:00:00Z");
+    private static final Duration RESOLUTION = Duration.ofHours(1);
+    private static final BigDecimal CI_VALUE = BigDecimal.valueOf(100);
+
+    private static List<CarbonIntensityPeriod> onePeriod() {
+        CarbonIntensity ci = new CarbonIntensity();
+        ci.setStart(CI_START.toInstant());
+        ci.setResolution(RESOLUTION);
+        ci.setData(List.of(CI_VALUE));
+        return CarbonIntensityPeriod.of(ci);
+    }
+
+    @Test
+    void jobExactlyCoveringThePeriodGetsItsFullValue() {
+        // start == ciStart, end == ciEnd - kills the "changed conditional boundary"/"negated
+        // conditional" mutants on line 78-79 that decide "full overlap".
+        BigDecimal result = Timeslot.calculateCarbonIntensity(onePeriod(), CI_START, CI_START.plus(RESOLUTION));
+
+        assertThat(result).isEqualByComparingTo(CI_VALUE);
+    }
+
+    @Test
+    void jobStartingExactlyAtThePeriodEndAndEndingAfterGetsNoWeightFromIt() {
+        // start == ciEnd (one instant past the boundary this test is guarding), well after the
+        // period - kills a "changed conditional boundary" mutant on line 82 by proving a job that
+        // starts right where the period ends does not get charged for it.
+        ZonedDateTime jobStart = CI_START.plus(RESOLUTION);
+        ZonedDateTime jobEnd = jobStart.plus(RESOLUTION);
+
+        BigDecimal result = Timeslot.calculateCarbonIntensity(onePeriod(), jobStart, jobEnd);
+
+        assertThat(result).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    void jobStartingInsideThePeriodAndEndingAfterGetsAProportionalShare() {
+        // start is 15 minutes (a quarter) into the hour-long period, ends well after it - exercises
+        // the "job starts in or on ci window, ends after" branch (line 82-89) with a start value
+        // that is neither the period's exact start nor exact end.
+        ZonedDateTime jobStart = CI_START.plus(Duration.ofMinutes(45));
+        ZonedDateTime jobEnd = jobStart.plus(RESOLUTION);
+
+        BigDecimal result = Timeslot.calculateCarbonIntensity(onePeriod(), jobStart, jobEnd);
+
+        // 15 of the period's 60 minutes overlap -> a quarter of its value.
+        assertThat(result).isEqualByComparingTo(BigDecimal.valueOf(25));
+    }
+
+    @Test
+    void jobEndingExactlyAtThePeriodStartGetsNoWeightFromIt() {
+        // end == ciStart - kills a "negated conditional"/"changed conditional boundary" mutant on
+        // line 95 by proving a job that ends exactly where the period begins isn't charged for it.
+        ZonedDateTime jobStart = CI_START.minus(RESOLUTION);
+        ZonedDateTime jobEnd = CI_START;
+
+        BigDecimal result = Timeslot.calculateCarbonIntensity(onePeriod(), jobStart, jobEnd);
+
+        assertThat(result).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    void jobEndingInsideThePeriodAndStartingBeforeGetsAProportionalShare() {
+        // starts well before the period, ends 15 minutes into it - exercises the "job ends in or on
+        // ci window, starts before" branch (line 95-98).
+        ZonedDateTime jobStart = CI_START.minus(RESOLUTION);
+        ZonedDateTime jobEnd = CI_START.plus(Duration.ofMinutes(15));
+
+        BigDecimal result = Timeslot.calculateCarbonIntensity(onePeriod(), jobStart, jobEnd);
+
+        assertThat(result).isEqualByComparingTo(BigDecimal.valueOf(25));
+    }
+
+    @Test
+    void jobEntirelyBeforeThePeriodGetsNoWeightFromIt() {
+        // Kills the "replaced return value with null" mutant on line 101 by exercising the "no
+        // overlap at all" fallback, which no existing test ever reaches.
+        ZonedDateTime jobStart = CI_START.minus(RESOLUTION).minus(RESOLUTION);
+        ZonedDateTime jobEnd = CI_START.minus(RESOLUTION);
+
+        BigDecimal result = Timeslot.calculateCarbonIntensity(onePeriod(), jobStart, jobEnd);
+
+        assertThat(result).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,10 @@
         <maven-enforcer-plugin.phase>validate</maven-enforcer-plugin.phase>
         <owasp-dependency-check-plugin.version>12.2.2</owasp-dependency-check-plugin.version>
         <jacoco.version>0.8.15</jacoco.version>
+        <!-- Pinned explicitly (not left to whatever's cached) - see the pitest-maven plugin
+             config in core/pom.xml and execution-planner/pom.xml for why. -->
+        <pitest-maven.version>1.30.0</pitest-maven.version>
+        <pitest-junit5-plugin.version>1.2.3</pitest-junit5-plugin.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Follow-up to #267 (already merged) — mutation testing (PIT) driven test improvements, tracked on CIIO-309.

## Mutation testing docs
Documents how to run PIT per module and a 3-shape checklist for future findings: weak assertion on return value, untested exact boundary, or genuine coverage gap (CIIO-332/333/334 superseded by the granular tickets below).

## Fixes four "looks fully tested but isn't" classes (CIIO-335/337/338)
`SkipConcurrentExecutionInvoker`, `StatusEmitterInvoker`, `ScheduledMethod`, `SchedulerContextImpl` all had 83-100% line coverage but a 0-40% mutation score: existing tests verified a side effect (a `CountDownLatch`, a listener callback) without ever asserting on what the method itself *returned*. Added direct unit tests asserting on the actual return values. Verified: all four now at 100% mutation score / 100% Test Strength.

## Timeslot/CarbonIntensityPeriod boundary tests (CIIO-336/339)
`Timeslot.calculateCarbonIntensity`'s overlap-boundary logic (95% coverage, 41% mutation score) and `CarbonIntensityPeriod` (had no direct test at all) now have tests that place a job's start/end exactly on a period boundary.

## Real bug found and fixed: CIIO-341
Writing those boundary tests surfaced a genuine production bug: `BigDecimal.divide(divisor, RoundingMode)` with no explicit scale rounds to the *dividend's* scale (0 for a typical integer-valued reading) before the multiply ever runs. Since a realistic carbon-intensity value is almost always smaller than a resolution in seconds (typically 3600), **every partial overlap between a job and a carbon-intensity period silently contributed zero** instead of a proportional share — only a full-period overlap ever counted. Fixed by multiplying before dividing, with an explicit scale.

## Test plan
- [x] `mvn -pl core,execution-planner -am install` — full build + tests pass
- [x] PIT re-run confirms 100% mutation score on all four "schijnzekerheid" classes
- [x] `TimeslotCalculateCarbonIntensityTest`'s two previously-failing (bug-revealing) tests now pass after the CIIO-341 fix