### PR TITLE
Property-test sweep: 3 confirmed bugs found and fixed

### DIFF
--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/impl/annotation/GreenScheduledAnnotationParser.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/impl/annotation/GreenScheduledAnnotationParser.java
@@ -135,10 +135,18 @@ public class GreenScheduledAnnotationParser {
         return new CronParser(definition).parse(cron);
     }
 
+    private static final int SECONDS_PER_DAY = 24 * 60 * 60;
+
     private static String calculateFallBackCronExpression(FixedWindowConstraints fixedWindow) {
         String cron;
         int dailyWindowInSeconds = fixedWindow.getEndTime().toLocalTime().toSecondOfDay()
                 - fixedWindow.getStartTime().toLocalTime().toSecondOfDay();
+        if (dailyWindowInSeconds < 0) {
+            // Overnight window (e.g. 23:15 -> 02:15): the end time-of-day is numerically smaller than the start
+            // time-of-day, so wrap the difference back into [0, SECONDS_PER_DAY) to get the window's actual
+            // duration instead of a negative value.
+            dailyWindowInSeconds += SECONDS_PER_DAY;
+        }
         LocalTime averageTime = fixedWindow.getStartTime().toLocalTime().plusSeconds(dailyWindowInSeconds / 2);
         cron = String.format("0 %s %s * * ?", averageTime.getMinute(), averageTime.getHour());
         return cron;

--- a/core/src/test/java/io/carbonintensity/scheduler/runtime/SkipConcurrentExecutionInvokerTest.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/runtime/SkipConcurrentExecutionInvokerTest.java
@@ -1,0 +1,289 @@
+package io.carbonintensity.scheduler.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import io.carbonintensity.scheduler.ScheduledExecution;
+import io.carbonintensity.scheduler.Scheduler;
+import io.carbonintensity.scheduler.Trigger;
+import io.vavr.test.Arbitrary;
+import io.vavr.test.Gen;
+import io.vavr.test.Property;
+
+/**
+ * Tests for {@link SkipConcurrentExecutionInvoker#invoke(ScheduledExecution)}.
+ * <p>
+ * The invariant under test is a thread-race one - "over any interleaving of concurrent {@code invoke()} calls, at
+ * most one delegate invocation runs at a time (CAS on the {@code running} flag), and after every completion
+ * (success or failure) the flag always clears again, so a later call is never permanently skipped" - but the
+ * mechanism itself (a single {@link java.util.concurrent.atomic.AtomicBoolean} guarded by
+ * {@link java.util.concurrent.atomic.AtomicBoolean#compareAndSet}, reset in a {@code whenComplete} callback) is
+ * deterministic once the delegate's {@link CompletionStage} is under test control. Rather than a real
+ * multi-threaded stress test, every test here drives a delegate backed by a hand-held {@link CompletableFuture}:
+ * it "hangs" until the test completes it, which lets a second/third {@code invoke()} call be interleaved
+ * deterministically without any real concurrency.
+ */
+class SkipConcurrentExecutionInvokerTest {
+
+    private static final String SKIPPED_DETAIL = "The scheduled method should not be executed concurrently";
+
+    @Test
+    void concurrentInvocationIsSkippedWhileFirstIsPending() throws Exception {
+        AtomicInteger skipCount = new AtomicInteger();
+        Events events = eventsCapturingSkips(skipCount);
+        ControllableInvoker delegate = new ControllableInvoker();
+        SkipConcurrentExecutionInvoker invoker = new SkipConcurrentExecutionInvoker(delegate, events);
+        ScheduledExecution execution = new FixedExecution();
+
+        invoker.invoke(execution);
+        assertThat(delegate.invocationCount()).isEqualTo(1);
+
+        // Second call arrives while the first delegate invocation is still pending: it must be skipped, not
+        // forwarded to the delegate.
+        CompletionStage<Void> skipped = invoker.invoke(execution);
+
+        assertThat(delegate.invocationCount()).isEqualTo(1);
+        assertThat(skipCount.get()).isEqualTo(1);
+        assertThat(skipped.toCompletableFuture()).isCompletedWithValue(null);
+    }
+
+    @Test
+    void skippedInvocationFiresSkipEventWithOriginalExecution() throws Exception {
+        AtomicInteger skipCount = new AtomicInteger();
+        ScheduledExecution[] skippedExecution = new ScheduledExecution[1];
+        String[] skippedDetail = new String[1];
+        Events events = events(List.of(new Scheduler.EventListener() {
+            @Override
+            public void jobExecutionSkipped(ScheduledExecution execution, String detail) {
+                skipCount.incrementAndGet();
+                skippedExecution[0] = execution;
+                skippedDetail[0] = detail;
+            }
+        }));
+        ControllableInvoker delegate = new ControllableInvoker();
+        SkipConcurrentExecutionInvoker invoker = new SkipConcurrentExecutionInvoker(delegate, events);
+        ScheduledExecution execution = new FixedExecution();
+
+        invoker.invoke(execution);
+        invoker.invoke(execution);
+
+        assertThat(skipCount.get()).isEqualTo(1);
+        assertThat(skippedExecution[0]).isSameAs(execution);
+        assertThat(skippedDetail[0]).isEqualTo(SKIPPED_DETAIL);
+    }
+
+    @Test
+    void flagIsClearedAfterSuccessfulCompletionSoNextInvocationProceeds() throws Exception {
+        Events events = eventsCapturingSkips(new AtomicInteger());
+        ControllableInvoker delegate = new ControllableInvoker();
+        SkipConcurrentExecutionInvoker invoker = new SkipConcurrentExecutionInvoker(delegate, events);
+        ScheduledExecution execution = new FixedExecution();
+
+        invoker.invoke(execution);
+        invoker.invoke(execution); // skipped while pending
+        assertThat(delegate.invocationCount()).isEqualTo(1);
+
+        delegate.mostRecentFuture().complete(null);
+
+        invoker.invoke(execution);
+        assertThat(delegate.invocationCount()).isEqualTo(2);
+    }
+
+    @Test
+    void flagIsClearedAfterExceptionalCompletionSoNextInvocationProceeds() throws Exception {
+        Events events = eventsCapturingSkips(new AtomicInteger());
+        ControllableInvoker delegate = new ControllableInvoker();
+        SkipConcurrentExecutionInvoker invoker = new SkipConcurrentExecutionInvoker(delegate, events);
+        ScheduledExecution execution = new FixedExecution();
+
+        invoker.invoke(execution);
+        invoker.invoke(execution); // skipped while pending
+        assertThat(delegate.invocationCount()).isEqualTo(1);
+
+        delegate.mostRecentFuture().completeExceptionally(new RuntimeException("boom"));
+
+        invoker.invoke(execution);
+        assertThat(delegate.invocationCount()).isEqualTo(2);
+    }
+
+    @Test
+    void flagIsClearedAfterSynchronousExceptionFromDelegate() throws Exception {
+        // The delegate throws directly, rather than returning a failed CompletionStage. DelegateInvoker#invokeDelegate
+        // catches this and converts it into an already-failed stage, so the whenComplete(...) that resets the
+        // "running" flag still gets attached (and, since the stage is already complete, runs synchronously) - the
+        // flag must not leak "stuck" in this path.
+        Events events = eventsCapturingSkips(new AtomicInteger());
+        ControllableInvoker delegate = new ControllableInvoker();
+        delegate.throwOnNextInvocation(new IllegalStateException("boom"));
+        SkipConcurrentExecutionInvoker invoker = new SkipConcurrentExecutionInvoker(delegate, events);
+        ScheduledExecution execution = new FixedExecution();
+
+        CompletionStage<Void> result = invoker.invoke(execution);
+
+        assertThat(result.toCompletableFuture()).isCompletedExceptionally();
+        assertThat(delegate.invocationCount()).isEqualTo(1);
+
+        // The flag must already be clear again, immediately - no separate "unstick" step should be needed.
+        invoker.invoke(execution);
+        assertThat(delegate.invocationCount()).isEqualTo(2);
+    }
+
+    /**
+     * Property-based complement to the example-based tests above: for any number of overlapping calls made while
+     * the first delegate invocation is still pending, and for either outcome (success or failure) it eventually
+     * completes with, the invariant holds - exactly one delegate invocation runs at a time, every overlapping call
+     * is skipped, and the flag is clear again afterwards so a further call proceeds. The actual interleaving stays
+     * deterministic/imperative inside each check; only the shape of the scenario is varied, so no real threads are
+     * needed.
+     * <p>
+     * See {@code docs/adr/0002-vavr-test-over-jqwik.md} (in carbonintensity-api) for why vavr-test rather than
+     * jqwik is used here.
+     */
+    @Test
+    void invariantHoldsForAnyNumberOfOverlappingCallsAndEitherOutcome() {
+        Arbitrary<Integer> overlappingCalls = Gen.choose(1, 5).arbitrary();
+        Arbitrary<Boolean> completesSuccessfully = Arbitrary.of(true, false);
+
+        Property.def("at most one delegate invocation runs concurrently, and the flag always clears afterwards")
+                .forAll(overlappingCalls, completesSuccessfully)
+                .suchThat((extraCalls, successfully) -> {
+                    try {
+                        return checkInvariant(extraCalls, successfully);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .check()
+                .assertIsSatisfied();
+    }
+
+    private boolean checkInvariant(int extraOverlappingCalls, boolean completesSuccessfully) throws Exception {
+        AtomicInteger skipCount = new AtomicInteger();
+        Events events = eventsCapturingSkips(skipCount);
+        ControllableInvoker delegate = new ControllableInvoker();
+        SkipConcurrentExecutionInvoker invoker = new SkipConcurrentExecutionInvoker(delegate, events);
+        ScheduledExecution execution = new FixedExecution();
+
+        invoker.invoke(execution);
+        for (int i = 0; i < extraOverlappingCalls; i++) {
+            invoker.invoke(execution);
+        }
+
+        boolean onlyOneRanConcurrently = delegate.invocationCount() == 1;
+        boolean everyOverlappingCallWasSkipped = skipCount.get() == extraOverlappingCalls;
+
+        if (completesSuccessfully) {
+            delegate.mostRecentFuture().complete(null);
+        } else {
+            delegate.mostRecentFuture().completeExceptionally(new RuntimeException("boom"));
+        }
+
+        invoker.invoke(execution);
+        boolean flagWasClearedAfterCompletion = delegate.invocationCount() == 2;
+
+        return onlyOneRanConcurrently && everyOverlappingCallWasSkipped && flagWasClearedAfterCompletion;
+    }
+
+    private static Events eventsCapturingSkips(AtomicInteger skipCount) {
+        return events(List.of(new Scheduler.EventListener() {
+            @Override
+            public void jobExecutionSkipped(ScheduledExecution execution, String detail) {
+                skipCount.incrementAndGet();
+            }
+        }));
+    }
+
+    private static Events events(List<Scheduler.EventListener> listeners) {
+        SimpleScheduler simpleScheduler = mock(SimpleScheduler.class);
+        when(simpleScheduler.getEventListeners()).thenReturn(listeners);
+        return new Events(simpleScheduler);
+    }
+
+    /**
+     * A {@link ScheduledInvoker} whose {@link CompletionStage} the test holds onto and completes by hand, so a
+     * concurrent invocation can be deterministically interleaved while the first is still "running".
+     */
+    private static final class ControllableInvoker implements ScheduledInvoker {
+
+        private final AtomicInteger invocationCount = new AtomicInteger();
+        private final Deque<CompletableFuture<Void>> pendingFutures = new ArrayDeque<>();
+        private RuntimeException nextSynchronousException;
+
+        @Override
+        public CompletionStage<Void> invoke(ScheduledExecution execution) {
+            invocationCount.incrementAndGet();
+            if (nextSynchronousException != null) {
+                RuntimeException toThrow = nextSynchronousException;
+                nextSynchronousException = null;
+                throw toThrow;
+            }
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            pendingFutures.addLast(future);
+            return future;
+        }
+
+        void throwOnNextInvocation(RuntimeException exception) {
+            this.nextSynchronousException = exception;
+        }
+
+        int invocationCount() {
+            return invocationCount.get();
+        }
+
+        CompletableFuture<Void> mostRecentFuture() {
+            return pendingFutures.getLast();
+        }
+    }
+
+    private static final class FixedTrigger implements Trigger {
+        @Override
+        public String getId() {
+            return "test-job";
+        }
+
+        @Override
+        public Instant getNextFireTime() {
+            return null;
+        }
+
+        @Override
+        public Instant getPreviousFireTime() {
+            return null;
+        }
+
+        @Override
+        public boolean isOverdue() {
+            return false;
+        }
+    }
+
+    private static final class FixedExecution implements ScheduledExecution {
+        private final Trigger trigger = new FixedTrigger();
+
+        @Override
+        public Trigger getTrigger() {
+            return trigger;
+        }
+
+        @Override
+        public Instant getFireTime() {
+            return Instant.EPOCH;
+        }
+
+        @Override
+        public Instant getScheduledFireTime() {
+            return Instant.EPOCH;
+        }
+    }
+}

--- a/core/src/test/java/io/carbonintensity/scheduler/runtime/impl/annotation/TestCalculateFallBackCronExpressionProperties.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/runtime/impl/annotation/TestCalculateFallBackCronExpressionProperties.java
@@ -1,0 +1,152 @@
+package io.carbonintensity.scheduler.runtime.impl.annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.junit.jupiter.api.Test;
+
+import com.cronutils.model.Cron;
+import com.cronutils.model.CronType;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.parser.CronParser;
+
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
+import io.vavr.test.Arbitrary;
+import io.vavr.test.Gen;
+import io.vavr.test.Property;
+
+/**
+ * Tests for {@link GreenScheduledAnnotationParser}'s private {@code calculateFallBackCronExpression}, alongside the
+ * example-based tests in {@link GreenScheduledAnnotationParserTest}.
+ * <p>
+ * The method computes a single daily "average" time-of-day between a fixed window's start and end, to use as a
+ * fallback cron trigger when no explicit {@code cron} is configured. It derives that average from
+ * {@code endTime.toSecondOfDay() - startTime.toSecondOfDay()}, which goes negative for an overnight window (e.g.
+ * 23:15 -> 02:15), producing a fallback time exactly 12 hours away from the actual midpoint of the window instead
+ * of inside it.
+ * <p>
+ * The method is private, so it is exercised here via reflection rather than through the full
+ * {@link GreenScheduledAnnotationParser#createConstraints} path - that path's next-occurrence/DST handling in
+ * {@link FixedWindowExpressionParser} is unrelated to this calculation and would only obscure it.
+ * <p>
+ * See {@code docs/adr/0002-vavr-test-over-jqwik.md} (in carbonintensity-api) for why vavr-test rather than
+ * jqwik is used here.
+ */
+class TestCalculateFallBackCronExpressionProperties {
+
+    private static final ZoneId UTC = ZoneId.of("UTC");
+    private static final LocalDate ANY_DATE = LocalDate.of(2024, 1, 1);
+
+    // A start/end pair of distinct times of day, at minute precision (seconds always :00) - built as an offset from
+    // the start rather than two independently generated times, so they can never accidentally collide (a
+    // zero-length window isn't a meaningful case here). Mirrors TestFixedWindowExpressionParserProperties's
+    // DISTINCT_WINDOW: the offset range of [1, 1439] means roughly half the generated windows are overnight (end
+    // minute-of-day < start minute-of-day). Keeping the seconds at :00 also avoids the fallback cron's own
+    // second-truncation (it only encodes hour:minute) from ever pulling the truncated average outside the window -
+    // a rounding artifact independent of this bug.
+    private static final Arbitrary<Tuple2<LocalTime, LocalTime>> DISTINCT_WINDOW = size -> Gen.choose(0, 1439)
+            .flatMap(startMinute -> Gen.choose(1, 1439)
+                    .map(offset -> Tuple.of(toLocalTime(startMinute), toLocalTime((startMinute + offset) % 1440))));
+
+    // CIIO-318: previously found that an overnight window (endTime < startTime) produced a fallback average time
+    // exactly 12 hours away from the true midpoint, because dailyWindowInSeconds went negative and integer division
+    // by 2 preserved the sign. Fixed by wrapping the negative difference back into [0, 86400) before halving.
+    @Test
+    void overnightWindowFallbackCronFallsInsideTheWindow() {
+        FixedWindowConstraints overnightWindow = toFixedWindowConstraints(LocalTime.of(23, 15), LocalTime.of(2, 15));
+
+        String fallbackCron = calculateFallBackCronExpression(overnightWindow);
+
+        // Midpoint of 23:15 -> 02:15 (a 3-hour window) is 00:45, not 12:45 (the pre-fix, 12-hours-off result).
+        assertThat(fallbackCron).isEqualTo("0 45 0 * * ?");
+    }
+
+    @Test
+    void nonOvernightWindowFallbackCronIsUnaffected() {
+        FixedWindowConstraints daytimeWindow = toFixedWindowConstraints(LocalTime.of(9, 30), LocalTime.of(11, 45));
+
+        String fallbackCron = calculateFallBackCronExpression(daytimeWindow);
+
+        assertThat(fallbackCron).isEqualTo("0 37 10 * * ?");
+    }
+
+    @Test
+    void fallbackCronIsAlwaysParseableAsAQuartzCronExpression() {
+        Property.def("calculateFallBackCronExpression(...) always yields a parseable Quartz cron expression")
+                .forAll(DISTINCT_WINDOW)
+                .suchThat(window -> {
+                    FixedWindowConstraints fixedWindow = toFixedWindowConstraints(window._1, window._2);
+                    String fallbackCron = calculateFallBackCronExpression(fixedWindow);
+                    Cron parsed = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ))
+                            .parse(fallbackCron);
+                    return parsed != null;
+                })
+                .check()
+                .assertIsSatisfied();
+    }
+
+    @Test
+    void fallbackCronAlwaysFallsInsideTheWindowItAverages() {
+        Property.def("calculateFallBackCronExpression(...) time-of-day lies within [startTime, endTime], wrapping "
+                + "across midnight for an overnight window")
+                .forAll(DISTINCT_WINDOW)
+                .suchThat(window -> {
+                    LocalTime startTime = window._1;
+                    LocalTime endTime = window._2;
+                    FixedWindowConstraints fixedWindow = toFixedWindowConstraints(startTime, endTime);
+
+                    String fallbackCron = calculateFallBackCronExpression(fixedWindow);
+                    LocalTime fallbackTime = parseHourMinute(fallbackCron);
+
+                    return isWithinWindow(fallbackTime, startTime, endTime);
+                })
+                .check()
+                .assertIsSatisfied();
+    }
+
+    private static boolean isWithinWindow(LocalTime candidate, LocalTime startTime, LocalTime endTime) {
+        int candidateMinute = candidate.getHour() * 60 + candidate.getMinute();
+        int startMinute = startTime.getHour() * 60 + startTime.getMinute();
+        int endMinute = endTime.getHour() * 60 + endTime.getMinute();
+        if (startMinute <= endMinute) {
+            return candidateMinute >= startMinute && candidateMinute <= endMinute;
+        }
+        // Overnight window: the valid range wraps across midnight.
+        return candidateMinute >= startMinute || candidateMinute <= endMinute;
+    }
+
+    private static LocalTime parseHourMinute(String quartzCron) {
+        // Cron format produced by calculateFallBackCronExpression: "0 <minute> <hour> * * ?"
+        String[] fields = quartzCron.split(" ");
+        int minute = Integer.parseInt(fields[1]);
+        int hour = Integer.parseInt(fields[2]);
+        return LocalTime.of(hour, minute);
+    }
+
+    private static FixedWindowConstraints toFixedWindowConstraints(LocalTime startTime, LocalTime endTime) {
+        return new FixedWindowConstraints(
+                ZonedDateTime.of(ANY_DATE, startTime, UTC),
+                ZonedDateTime.of(ANY_DATE, endTime, UTC));
+    }
+
+    private static String calculateFallBackCronExpression(FixedWindowConstraints fixedWindow) {
+        try {
+            Method method = GreenScheduledAnnotationParser.class.getDeclaredMethod("calculateFallBackCronExpression",
+                    FixedWindowConstraints.class);
+            method.setAccessible(true);
+            return (String) method.invoke(null, fixedWindow);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static LocalTime toLocalTime(int minuteOfDay) {
+        return LocalTime.of(minuteOfDay / 60, minuteOfDay % 60);
+    }
+}

--- a/core/src/test/java/io/carbonintensity/scheduler/runtime/impl/annotation/TestDurationFieldParserProperties.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/runtime/impl/annotation/TestDurationFieldParserProperties.java
@@ -1,0 +1,110 @@
+package io.carbonintensity.scheduler.runtime.impl.annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import io.vavr.test.Arbitrary;
+import io.vavr.test.Gen;
+import io.vavr.test.Property;
+
+/**
+ * Property-based tests for {@link DurationFieldParser#parseDuration}, alongside its incidental coverage as
+ * literal strings ("15m", "30m", "1h") in {@link SuccessiveExpressionParser} and
+ * {@link GreenScheduledAnnotationParser} tests.
+ * <p>
+ * This class was picked for property-based testing because {@code parseDuration} is shared by both scheduling
+ * modes ({@link SuccessiveExpressionParser} and the duration field parsed via
+ * {@link GreenScheduledAnnotationParser}) - an edge case here affects both - yet it had no dedicated test
+ * class and no negative/zero/case-variant coverage.
+ * <p>
+ * The core invariant checked here: for a digit-starting simplified duration string (e.g. "15m", "1h", "2d"),
+ * {@code parseDuration} must produce exactly the same {@link Duration} as parsing the equivalent full
+ * ISO-8601 P/PT form directly (e.g. "PT15M", "PT1H", "P2D") - and the suffix's case ('d' vs 'D', etc.) must
+ * never change the result.
+ *
+ * <p>
+ * See {@code docs/adr/0002-vavr-test-over-jqwik.md} (in carbonintensity-api) for why vavr-test rather than
+ * jqwik is used here.
+ */
+class TestDurationFieldParserProperties {
+
+    // The single-letter ISO-8601 duration designators DurationFieldParser actually branches on: 'D' takes the
+    // bare "P" prefix, while H/M/S all take "PT" - covering both branches of that if/else.
+    private static final Arbitrary<Character> UNITS = size -> Gen.choose(new char[] { 'D', 'H', 'M', 'S' });
+
+    // Zero included deliberately: it is the boundary where "P0D" and "PT0H"/"PT0M"/"PT0S" all collapse to the
+    // same Duration.ZERO, which is exactly the kind of degenerate case example-based tests tend to skip.
+    private static final Arbitrary<Long> MAGNITUDES = size -> Gen.choose(0L, 1_000_000L);
+
+    private static final Arbitrary<Boolean> LOWERCASE_SUFFIX = size -> Gen.choose(true, false);
+
+    @Test
+    void simplifiedFormMatchesFullIsoForm() {
+        Property.def("parseDuration(<n><unit>) == Duration.parse(equivalent full ISO-8601 P/PT form)")
+                .forAll(MAGNITUDES, UNITS, LOWERCASE_SUFFIX)
+                .suchThat((magnitude, unit, lowercase) -> {
+                    String simplified = magnitude + suffix(unit, lowercase);
+                    String fullIso = unit == 'D' ? "P" + magnitude + "D" : "PT" + magnitude + unit;
+
+                    Duration actual = DurationFieldParser.parseDuration(simplified);
+                    Duration expected = Duration.parse(fullIso);
+
+                    return actual.equals(expected);
+                })
+                .check()
+                .assertIsSatisfied();
+    }
+
+    @Test
+    void suffixCaseNeverChangesTheResult() {
+        Property.def("parseDuration(<n><unit>) == parseDuration(<n><UNIT>) regardless of suffix case")
+                .forAll(MAGNITUDES, UNITS)
+                .suchThat((magnitude, unit) -> {
+                    Duration lower = DurationFieldParser.parseDuration(magnitude + suffix(unit, true));
+                    Duration upper = DurationFieldParser.parseDuration(magnitude + suffix(unit, false));
+
+                    return lower.equals(upper);
+                })
+                .check()
+                .assertIsSatisfied();
+    }
+
+    // Deterministic complements to the properties above: the exact examples named in the ticket, so a
+    // regression is caught on every run rather than only when the property generator happens to land on one.
+
+    @Test
+    void fifteenMinutesMatchesFullIsoForm() {
+        assertThat(DurationFieldParser.parseDuration("15m")).isEqualTo(Duration.parse("PT15M"));
+    }
+
+    @Test
+    void oneHourMatchesFullIsoForm() {
+        assertThat(DurationFieldParser.parseDuration("1h")).isEqualTo(Duration.parse("PT1H"));
+    }
+
+    @Test
+    void twoDaysMatchesFullIsoForm() {
+        assertThat(DurationFieldParser.parseDuration("2d")).isEqualTo(Duration.parse("P2D"));
+    }
+
+    @Test
+    void zeroIsTheSameDurationRegardlessOfUnit() {
+        assertThat(DurationFieldParser.parseDuration("0d"))
+                .isEqualTo(DurationFieldParser.parseDuration("0h"))
+                .isEqualTo(DurationFieldParser.parseDuration("0m"))
+                .isEqualTo(DurationFieldParser.parseDuration("0s"))
+                .isEqualTo(Duration.ZERO);
+    }
+
+    @Test
+    void uppercaseDaySuffixIsEquivalentToLowercase() {
+        assertThat(DurationFieldParser.parseDuration("2D")).isEqualTo(DurationFieldParser.parseDuration("2d"));
+    }
+
+    private static String suffix(char unit, boolean lowercase) {
+        return lowercase ? String.valueOf(Character.toLowerCase(unit)) : String.valueOf(unit);
+    }
+}

--- a/core/src/test/java/io/carbonintensity/scheduler/runtime/impl/annotation/TestGreenScheduledAnnotationParserProperties.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/runtime/impl/annotation/TestGreenScheduledAnnotationParserProperties.java
@@ -1,0 +1,140 @@
+package io.carbonintensity.scheduler.runtime.impl.annotation;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.jupiter.api.Test;
+
+import com.cronutils.model.Cron;
+import com.cronutils.model.time.ExecutionTime;
+
+import io.vavr.Tuple;
+import io.vavr.Tuple3;
+import io.vavr.test.Arbitrary;
+import io.vavr.test.Gen;
+import io.vavr.test.Property;
+
+/**
+ * Property-based tests for {@link GreenScheduledAnnotationParser#parseCronExpression}, alongside the example-based
+ * tests in {@link GreenScheduledAnnotationParserTest}.
+ * <p>
+ * The core invariant checked here is that for any {@code startTime} and any mutually-exclusive dayOfMonth/dayOfWeek
+ * expression that (as validated separately by {@link GreenScheduledAnnotationValidation}) actually covers that
+ * {@code startTime}'s own day, the generated Quartz cron string parses successfully and matches the
+ * second-truncated {@code startTime} - across the full boundary range of second (0/59), hour (0/23) and
+ * day-of-month/day-of-week expression styles (exact value, wildcard, list).
+ * <p>
+ * A second property checks the complementary case: a dayOfMonth/dayOfWeek value that is syntactically invalid for
+ * Quartz (out of range or not a cron token at all) always fails predictably with an {@link IllegalArgumentException},
+ * rather than silently producing a cron that parses but matches the wrong thing.
+ *
+ * <p>
+ * See {@code docs/adr/0002-vavr-test-over-jqwik.md} (in carbonintensity-api) for why vavr-test rather than
+ * jqwik is used here.
+ */
+class TestGreenScheduledAnnotationParserProperties {
+
+    private static final ZoneId AMSTERDAM = ZoneId.of("Europe/Amsterdam");
+
+    private static final Gen<LocalDate> DATES = Gen.choose(0, 365 * 8)
+            .map(offset -> LocalDate.of(2022, 1, 1).plusDays(offset));
+
+    // Skewed towards the second/hour boundaries (0 and the max value), mixed with values from the rest of the
+    // range, so a typical run exercises both edges and the ordinary case.
+    private static final Gen<Integer> SECONDS = Gen.frequency(
+            Tuple.of(1, Gen.of(0)), Tuple.of(1, Gen.of(59)), Tuple.of(3, Gen.choose(1, 58)));
+    private static final Gen<Integer> HOURS = Gen.frequency(
+            Tuple.of(1, Gen.of(0)), Tuple.of(1, Gen.of(23)), Tuple.of(3, Gen.choose(1, 22)));
+    private static final Gen<Integer> MINUTES = Gen.choose(0, 59);
+
+    private static final Arbitrary<ZonedDateTime> START_TIMES = size -> DATES
+            .flatMap(date -> HOURS
+                    .flatMap(hour -> MINUTES
+                            .flatMap(minute -> SECONDS
+                                    .map(second -> ZonedDateTime.of(date, LocalTime.of(hour, minute, second), AMSTERDAM)))));
+
+    // A dayOfMonth/dayOfWeek expression that is guaranteed to cover the startTime's own day - as an exact value,
+    // a wildcard, or a list containing it - so the resulting cron can be expected to match. "none" (both blank)
+    // is included too, since that is a valid combination handled by parseCronExpression itself.
+    private static final Arbitrary<Tuple3<ZonedDateTime, String, String>> START_TIME_WITH_MATCHING_DAY_FIELDS = size -> START_TIMES
+            .apply(size)
+            .flatMap(startTime -> Gen.choose(0, 5).map(dayFieldStyle -> {
+                int dayOfMonth = startTime.getDayOfMonth();
+                String dayOfWeekName = startTime.getDayOfWeek().name().substring(0, 3); // e.g. MONDAY -> MON
+                switch (dayFieldStyle) {
+                    case 0:
+                        return Tuple.of(startTime, "", ""); // neither set
+                    case 1:
+                        return Tuple.of(startTime, String.valueOf(dayOfMonth), ""); // dayOfMonth exact value
+                    case 2:
+                        return Tuple.of(startTime, "*", ""); // dayOfMonth wildcard
+                    case 3:
+                        return Tuple.of(startTime, dayOfMonth + ",1,15", ""); // dayOfMonth list containing it
+                    case 4:
+                        return Tuple.of(startTime, "", dayOfWeekName); // dayOfWeek exact value
+                    default:
+                        return Tuple.of(startTime, "", "*"); // dayOfWeek wildcard
+                }
+            }));
+
+    @Test
+    void generatedCronMatchesTheSecondTruncatedStartTime() {
+        Property.def("parseCronExpression(...) parses and matches the second-truncated startTime")
+                .forAll(START_TIME_WITH_MATCHING_DAY_FIELDS)
+                .suchThat(startTimeWithDayFields -> {
+                    ZonedDateTime startTime = startTimeWithDayFields._1;
+                    String dayOfMonth = startTimeWithDayFields._2;
+                    String dayOfWeek = startTimeWithDayFields._3;
+
+                    Cron cron = GreenScheduledAnnotationParser.parseCronExpression(startTime, dayOfMonth, dayOfWeek);
+
+                    return ExecutionTime.forCron(cron).isMatch(startTime.truncatedTo(ChronoUnit.SECONDS));
+                })
+                .check()
+                .assertIsSatisfied();
+    }
+
+    // dayOfMonth values that Quartz cannot parse at all: out of its valid 1-31 range, or not a cron token.
+    // Note: unlike dayOfWeek, "8" and "13" are valid dayOfMonth values, so they are deliberately excluded here.
+    private static final Arbitrary<String> INVALID_DAY_OF_MONTH_VALUES = Arbitrary.of(
+            "0", "32", "40", "-1", "abc", "MON-", "FOO", "*/0", "99");
+
+    // dayOfWeek values that Quartz cannot parse at all: out of its valid 1-7 range, or not a cron token.
+    private static final Arbitrary<String> INVALID_DAY_OF_WEEK_VALUES = Arbitrary.of(
+            "0", "8", "13", "abc", "FOO", "MON-", "SUN-", "*/0", "99");
+
+    @Test
+    void invalidDayOfMonthAlwaysThrowsIllegalArgumentException() {
+        Property.def("parseCronExpression(...) rejects an invalid dayOfMonth")
+                .forAll(START_TIMES, INVALID_DAY_OF_MONTH_VALUES)
+                .suchThat((startTime, invalidDayOfMonth) -> {
+                    assertThatThrownBy(() -> GreenScheduledAnnotationParser.parseCronExpression(startTime, invalidDayOfMonth,
+                            null))
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessageContaining("Invalid CRON format");
+                    return true;
+                })
+                .check()
+                .assertIsSatisfied();
+    }
+
+    @Test
+    void invalidDayOfWeekAlwaysThrowsIllegalArgumentException() {
+        Property.def("parseCronExpression(...) rejects an invalid dayOfWeek")
+                .forAll(START_TIMES, INVALID_DAY_OF_WEEK_VALUES)
+                .suchThat((startTime, invalidDayOfWeek) -> {
+                    assertThatThrownBy(() -> GreenScheduledAnnotationParser.parseCronExpression(startTime, null,
+                            invalidDayOfWeek))
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessageContaining("Invalid CRON format");
+                    return true;
+                })
+                .check()
+                .assertIsSatisfied();
+    }
+}

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/CarbonIntensityPeriod.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/CarbonIntensityPeriod.java
@@ -70,8 +70,17 @@ public class CarbonIntensityPeriod implements Comparable<CarbonIntensityPeriod> 
                 .compare(this, o);
     }
 
+    /**
+     * Whether {@code point} falls within this period, using a half-open interval
+     * {@code [moment, moment + resolution)}.
+     * <p>
+     * The upper bound is deliberately exclusive: {@link #of(CarbonIntensity)} produces contiguous periods where
+     * {@code period[i].moment() + resolution == period[i + 1].moment()}. If both bounds were inclusive, that shared
+     * boundary instant would be reported as contained by two consecutive periods at once, which would double-count
+     * it wherever {@code contains} is used to select overlapping periods (e.g. {@link Timeslot#calculateCarbonIntensity}).
+     */
     public boolean contains(Instant point) {
-        return point.compareTo(instant) >= 0 && point.compareTo(instant.plus(resolution)) <= 0;
+        return point.compareTo(instant) >= 0 && point.isBefore(instant.plus(resolution));
     }
 
     @Override

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/runtime/impl/CarbonIntensityCache.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/runtime/impl/CarbonIntensityCache.java
@@ -49,14 +49,8 @@ public class CarbonIntensityCache {
                 .expireAfter(new Expiry<Key, CarbonIntensity>() {
                     @Override
                     public long expireAfterCreate(Key key, CarbonIntensity value, long currentTime) {
-                        if (value.getData().isEmpty()) {
-                            return emptyValueTTL.toNanos();
-                        }
                         Instant current = Instant.ofEpochSecond(0L, currentTime);
-
-                        // expire endTime of day.
-                        var expirationTime = value.getEnd().plusSeconds(1);
-                        return Duration.between(current, expirationTime).toNanos();
+                        return computeExpireAfterCreateNanos(value, current, emptyValueTTL);
                     }
 
                     @Override
@@ -71,6 +65,26 @@ public class CarbonIntensityCache {
                         return currentDuration;
                     }
                 }).build();
+    }
+
+    /**
+     * Computes the nanosecond TTL that {@code expireAfterCreate} hands to Caffeine, as a standalone pure
+     * function so it can be property-tested directly.
+     * <p>
+     * Clamps to zero instead of returning a negative value: if {@code value.getEnd()} already lies in the
+     * past relative to {@code currentTime} (e.g. a stale entry re-created after being retrieved from a slow
+     * upstream call), {@code Duration.between(...)} is negative, and Caffeine's {@link Expiry} contract
+     * treats a negative return value as undefined behaviour. Zero tells Caffeine to expire the entry
+     * immediately, which is the correct outcome for already-stale data.
+     */
+    static long computeExpireAfterCreateNanos(CarbonIntensity value, Instant currentTime, Duration emptyValueTTL) {
+        if (value.getData().isEmpty()) {
+            return emptyValueTTL.toNanos();
+        }
+
+        // expire endTime of day.
+        var expirationTime = value.getEnd().plusSeconds(1);
+        return Math.max(0L, Duration.between(currentTime, expirationTime).toNanos());
     }
 
     public static class Key {

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/TestCarbonIntensityPeriodProperties.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/TestCarbonIntensityPeriodProperties.java
@@ -1,0 +1,116 @@
+package io.carbonintensity.executionplanner.planner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensity;
+import io.vavr.test.Arbitrary;
+import io.vavr.test.Gen;
+import io.vavr.test.Property;
+
+/**
+ * Property-based tests for {@link CarbonIntensityPeriod#of(CarbonIntensity)} and
+ * {@link CarbonIntensityPeriod#contains(Instant)},
+ * alongside the example-based coverage of {@link Timeslot} in {@code TestTimeslot}.
+ * <p>
+ * See {@code docs/adr/0002-vavr-test-over-jqwik.md} (in carbonintensity-api) for why vavr-test rather than
+ * jqwik is used here.
+ */
+class TestCarbonIntensityPeriodProperties {
+
+    // Arbitrary start instants spread across a multi-year range, so generated periods land on a variety of
+    // moments rather than always near the epoch.
+    private static final Gen<Instant> STARTS_GEN = Gen.choose(0L, 4L * 365 * 24 * 60 * 60)
+            .map(Instant::ofEpochSecond);
+    private static final Arbitrary<Instant> STARTS = size -> STARTS_GEN;
+
+    // Resolutions actually used in practice (quarter-hourly, half-hourly, hourly).
+    private static final Gen<Duration> RESOLUTIONS_GEN = Gen.choose(Duration.ofMinutes(15), Duration.ofMinutes(30),
+            Duration.ofHours(1));
+    private static final Arbitrary<Duration> RESOLUTIONS = size -> RESOLUTIONS_GEN;
+
+    // At least 2 data points, so there is always at least one adjacent pair of periods to check.
+    private static final Gen<Integer> DATA_SIZES_GEN = Gen.choose(2, 20);
+    private static final Arbitrary<Integer> DATA_SIZES = size -> DATA_SIZES_GEN;
+
+    // CIIO-366: contains(...) used to be doubly-inclusive ([moment, moment + resolution], both bounds closed),
+    // so the instant shared by two consecutive periods (A.moment() + resolution == B.moment()) was reported as
+    // contained by both A and B at once. Fixed in CarbonIntensityPeriod#contains by making the interval half-open
+    // ([moment, moment + resolution)), matching the contiguous, non-overlapping periods that of(...) produces.
+    // Before the fix: a.contains(boundary) && b.contains(boundary) could both be true.
+    // After the fix: exactly b.contains(boundary) is true, a.contains(boundary) is false.
+    @Test
+    void adjacentPeriodsDoNotBothContainTheSharedBoundaryInstant() {
+        Property.def("for adjacent periods A, B where B starts exactly where A ends, "
+                + "the shared boundary instant is not contained by both at once")
+                .forAll(STARTS, RESOLUTIONS, DATA_SIZES)
+                .suchThat((start, resolution, size) -> {
+                    List<CarbonIntensityPeriod> periods = buildPeriods(start, resolution, size);
+                    for (int i = 0; i < periods.size() - 1; i++) {
+                        CarbonIntensityPeriod a = periods.get(i);
+                        CarbonIntensityPeriod b = periods.get(i + 1);
+                        Instant boundary = a.moment().plus(resolution);
+                        if (a.contains(boundary) && b.contains(boundary)) {
+                            return false;
+                        }
+                    }
+                    return true;
+                })
+                .check()
+                .assertIsSatisfied();
+    }
+
+    // Deterministic complement to the property above: a concrete pair of adjacent periods, so a regression is
+    // caught on every run rather than only when the property generator happens to land on this shape.
+    @Test
+    void boundaryInstantBelongsOnlyToTheLaterPeriod() {
+        Instant start = Instant.parse("2024-08-27T00:00:00Z");
+        Duration resolution = Duration.ofMinutes(15);
+        List<CarbonIntensityPeriod> periods = buildPeriods(start, resolution, 2);
+
+        CarbonIntensityPeriod a = periods.get(0);
+        CarbonIntensityPeriod b = periods.get(1);
+        Instant boundary = a.moment().plus(resolution);
+
+        assertThat(boundary).isEqualTo(b.moment());
+        assertThat(a.contains(boundary)).isFalse();
+        assertThat(b.contains(boundary)).isTrue();
+    }
+
+    // Invariant 1: of(...) always produces contiguous periods, regardless of start instant, resolution or data size.
+    @Test
+    void generatedPeriodsAreContiguous() {
+        Property.def("CarbonIntensityPeriod.of(...) produces contiguous periods: "
+                + "period[i].moment() + resolution == period[i + 1].moment()")
+                .forAll(STARTS, RESOLUTIONS, DATA_SIZES)
+                .suchThat((start, resolution, size) -> {
+                    List<CarbonIntensityPeriod> periods = buildPeriods(start, resolution, size);
+                    for (int i = 0; i < periods.size() - 1; i++) {
+                        if (!periods.get(i).moment().plus(resolution).equals(periods.get(i + 1).moment())) {
+                            return false;
+                        }
+                    }
+                    return true;
+                })
+                .check()
+                .assertIsSatisfied();
+    }
+
+    private static List<CarbonIntensityPeriod> buildPeriods(Instant start, Duration resolution, int size) {
+        CarbonIntensity carbonIntensity = new CarbonIntensity();
+        carbonIntensity.setStart(start);
+        carbonIntensity.setResolution(resolution);
+        carbonIntensity.setData(IntStream.range(0, size)
+                .mapToObj(BigDecimal::valueOf)
+                .collect(Collectors.toList()));
+        return CarbonIntensityPeriod.of(carbonIntensity);
+    }
+}

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/TestTimeslotProperties.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/TestTimeslotProperties.java
@@ -1,0 +1,129 @@
+package io.carbonintensity.executionplanner.planner;
+
+import static java.time.Duration.ofMinutes;
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensity;
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
+import io.vavr.test.Arbitrary;
+import io.vavr.test.Gen;
+import io.vavr.test.Property;
+
+/**
+ * Property-based tests for {@link Timeslot#getTimeslots}, alongside the example-based tests in
+ * {@link TestTimeslot}.
+ * <p>
+ * The invariant checked here: for any window {@code [ws, we]}, {@code timeslotDuration} and {@code resolution},
+ * {@code getTimeslots} generates exactly {@code floor((we-ws)/resolution) + 1} slots, starting at
+ * {@code ws + i*resolution} for {@code i = 0..n-1}, and never starting past {@code we}. Window length and
+ * resolution are generated independently, so a resolution that does NOT evenly divide the window is the common
+ * case rather than something that needs to be special-cased.
+ *
+ * <p>
+ * See {@code docs/adr/0002-vavr-test-over-jqwik.md} (in carbonintensity-api) for why vavr-test rather than
+ * jqwik is used here.
+ */
+class TestTimeslotProperties {
+
+    private static final ZoneId AMSTERDAM = ZoneId.of("Europe/Amsterdam");
+
+    // getTimeslots doesn't consult any carbon intensity data to decide how many slots to generate or where they
+    // start - an empty CarbonIntensity (no data points) keeps calculateCarbonIntensity a no-op (BigDecimal.ZERO),
+    // so the property below can focus purely on the slot-count/start-time invariant.
+    private static final CarbonIntensity EMPTY_CARBON_INTENSITY = new CarbonIntensity();
+
+    private static final Arbitrary<ZonedDateTime> WINDOW_STARTS = size -> Gen.choose(0L, 4L * 365 * 24 * 3600)
+            .map(offsetSeconds -> ZonedDateTime.ofInstant(Instant.EPOCH.plusSeconds(offsetSeconds), ZoneOffset.UTC));
+
+    // Window length and resolution, both in seconds, generated independently of one another (and including 0 for
+    // the window length, to exercise the "allow equal for 0 windows" edge case).
+    private static final Arbitrary<Tuple2<Long, Long>> WINDOW_LENGTH_AND_RESOLUTION = size -> Gen.choose(0L, 2_000L)
+            .flatMap(
+                    windowSeconds -> Gen.choose(1L, 200L).map(resolutionSeconds -> Tuple.of(windowSeconds, resolutionSeconds)));
+
+    @Test
+    void numberOfSlotsAndTheirStartTimesMatchTheClosedFormFormula() {
+        Property
+                .def("getTimeslots(ws, we, ...) generates floor((we-ws)/resolution)+1 slots starting at ws+i*resolution, never past we")
+                .forAll(WINDOW_STARTS, WINDOW_LENGTH_AND_RESOLUTION)
+                .suchThat((ws, windowAndResolution) -> {
+                    long windowSeconds = windowAndResolution._1;
+                    long resolutionSeconds = windowAndResolution._2;
+                    ZonedDateTime we = ws.plusSeconds(windowSeconds);
+                    Duration resolution = ofSeconds(resolutionSeconds);
+                    // irrelevant to the slot count/positions invariant under test; kept fixed and short
+                    Duration timeslotDuration = ofSeconds(1);
+
+                    List<Timeslot> timeslots = Timeslot.getTimeslots(ws, we, timeslotDuration, resolution,
+                            EMPTY_CARBON_INTENSITY);
+
+                    long expectedCount = windowSeconds / resolutionSeconds + 1;
+                    if (timeslots.size() != expectedCount) {
+                        return false;
+                    }
+                    for (int i = 0; i < timeslots.size(); i++) {
+                        ZonedDateTime expectedStart = ws.plusSeconds(i * resolutionSeconds);
+                        ZonedDateTime actualStart = timeslots.get(i).start();
+                        if (!actualStart.isEqual(expectedStart) || actualStart.isAfter(we)) {
+                            return false;
+                        }
+                    }
+                    // one slot beyond the generated ones would always overshoot the window
+                    ZonedDateTime afterLastSlot = ws.plusSeconds(timeslots.size() * resolutionSeconds);
+                    return afterLastSlot.isAfter(we);
+                })
+                .check()
+                .assertIsSatisfied();
+    }
+
+    // Deterministic complements to the property above.
+
+    @Test
+    void zeroLengthWindowGeneratesExactlyOneSlot() {
+        // the "allow equal for 0 windows" case in Timeslot.getTimeslots's loop condition (!s.isAfter(we))
+        ZonedDateTime ws = ZonedDateTime.parse("2024-08-27T00:00:00Z");
+        ZonedDateTime we = ws;
+
+        List<Timeslot> timeslots = Timeslot.getTimeslots(ws, we, ofMinutes(60), ofSeconds(1), EMPTY_CARBON_INTENSITY);
+
+        assertThat(timeslots).hasSize(1);
+        assertThat(timeslots.get(0).start()).isEqualTo(ws);
+    }
+
+    @Test
+    void springForwardDayHas23HoursWorthOfTimeslots() {
+        // Europe/Amsterdam DST: clocks skip forward an hour, so this calendar "day" is only 23 real hours long.
+        ZonedDateTime ws = ZonedDateTime.of(2025, 3, 30, 0, 0, 0, 0, AMSTERDAM);
+        ZonedDateTime we = ws.plusDays(1);
+        assertThat(Duration.between(ws, we)).isEqualTo(Duration.ofHours(23));
+
+        List<Timeslot> timeslots = Timeslot.getTimeslots(ws, we, ofMinutes(60), ofMinutes(15), EMPTY_CARBON_INTENSITY);
+
+        assertThat(timeslots).hasSize(23 * 4 + 1);
+        assertThat(timeslots.get(timeslots.size() - 1).start()).isEqualTo(we);
+    }
+
+    @Test
+    void fallBackDayHas25HoursWorthOfTimeslots() {
+        // Europe/Amsterdam DST: clocks fall back an hour, so this calendar "day" is 25 real hours long.
+        ZonedDateTime ws = ZonedDateTime.of(2025, 10, 26, 0, 0, 0, 0, AMSTERDAM);
+        ZonedDateTime we = ws.plusDays(1);
+        assertThat(Duration.between(ws, we)).isEqualTo(Duration.ofHours(25));
+
+        List<Timeslot> timeslots = Timeslot.getTimeslots(ws, we, ofMinutes(60), ofMinutes(15), EMPTY_CARBON_INTENSITY);
+
+        assertThat(timeslots).hasSize(25 * 4 + 1);
+        assertThat(timeslots.get(timeslots.size() - 1).start()).isEqualTo(we);
+    }
+}

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/fixedwindow/TestDefaultFixedWindowPlanningConstraintsProperties.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/fixedwindow/TestDefaultFixedWindowPlanningConstraintsProperties.java
@@ -1,0 +1,168 @@
+package io.carbonintensity.executionplanner.planner.fixedwindow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.jupiter.api.Test;
+
+import com.cronutils.model.Cron;
+import com.cronutils.model.CronType;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.model.time.ExecutionTime;
+import com.cronutils.parser.CronParser;
+
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
+import io.vavr.control.Option;
+import io.vavr.test.Arbitrary;
+import io.vavr.test.Gen;
+import io.vavr.test.Property;
+
+/**
+ * Property-based tests for the day-shifting logic in {@link DefaultFixedWindowPlanningConstraints}
+ * ({@code checkStartTime}/{@code calculateDelayedDays}, exercised here through the public constructor/builder
+ * since both methods are private), alongside the hand-picked examples in {@link TestFixedWindowPlanner}.
+ * <p>
+ * Those existing examples all derive their cron and start time from {@code ZonedDateTime.now()}, so they never
+ * pin a specific month/year boundary or leap day, and none of them drives the search past its 35-day cap into
+ * the fallback path. This class targets exactly that: a {@code startTime} paired with a day-of-month-only or
+ * day-of-week-only cron, skewed towards month ends (including 29/30/31, which don't exist in every month) and
+ * year boundaries, plus the pinned 2024-02-29 leap day.
+ * <p>
+ * The invariant: the constructed constraints' start is {@code startTime} shifted by the smallest non-negative
+ * number of days such that the cron matches - found independently in this test via a plain brute-force search
+ * over the same 0..34 day horizon the production code uses (day 0 via {@code checkStartTime}, days 1..34 via
+ * {@code calculateDelayedDays}'s loop) - or, if no day in that horizon matches, the shift is 0 (the documented
+ * fallback, logged rather than applied silently).
+ *
+ * <p>
+ * See {@code docs/adr/0002-vavr-test-over-jqwik.md} (in carbonintensity-api) for why vavr-test rather than
+ * jqwik is used here.
+ */
+class TestDefaultFixedWindowPlanningConstraintsProperties {
+
+    private static final ZoneId UTC = ZoneId.of("UTC");
+
+    // Same cap as DefaultFixedWindowPlanningConstraints: checkStartTime covers day 0, and
+    // calculateDelayedDays' loop covers days 1..34, so 35 candidate days are examined in total.
+    private static final int HORIZON_DAYS = 35;
+
+    private static final CronParser QUARTZ_PARSER = new CronParser(
+            CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
+    private static final Cron FALLBACK_CRON = QUARTZ_PARSER.parse("0 0 12 * * ?");
+
+    private static final String[] DAY_OF_WEEK_NAMES = { "MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN" };
+
+    // Skewed towards the last day of a month (28/29/30/31 - not every month has a 31st, or even a 29th, which
+    // is exactly what makes a day-of-month cron interesting here), mixed with the pinned 2024 leap day and
+    // plain dates spread across a 5-year span that includes a leap year.
+    private static final Gen<LocalDate> DATES = Gen.frequency(
+            Tuple.of(4,
+                    Gen.choose(2023, 2027).flatMap(
+                            year -> Gen.choose(1, 12).map(month -> YearMonth.of(year, month).atEndOfMonth()))),
+            Tuple.of(1, Gen.of(LocalDate.of(2024, 2, 29))),
+            Tuple.of(5, Gen.choose(0, 365 * 5).map(offset -> LocalDate.of(2023, 1, 1).plusDays(offset))));
+
+    // A start time together with a cron whose seconds/minutes/hours match that start time exactly, and whose
+    // day-of-month (kind 0) or day-of-week (kind 1) field is randomized - isolating the day-stepping search
+    // from time-of-day matching, which is not what's under test here.
+    private static final Arbitrary<Tuple2<ZonedDateTime, Cron>> START_AND_CRON = size -> DATES
+            .flatMap(date -> Gen.choose(0, 23)
+                    .flatMap(hour -> Gen.choose(0, 59)
+                            .flatMap(minute -> Gen.choose(0, 59)
+                                    .flatMap(second -> Gen.choose(0, 1).flatMap(kind -> {
+                                        ZonedDateTime startTime = ZonedDateTime.of(date,
+                                                LocalTime.of(hour, minute, second), UTC);
+                                        Gen<Cron> cronGen = kind == 0
+                                                ? Gen.choose(1, 31)
+                                                        .map(dayOfMonth -> dayOfMonthCron(second, minute, hour,
+                                                                dayOfMonth))
+                                                : Gen.choose(DAY_OF_WEEK_NAMES)
+                                                        .map(dayOfWeek -> dayOfWeekCron(second, minute, hour,
+                                                                dayOfWeek));
+                                        return cronGen.map(cron -> Tuple.of(startTime, cron));
+                                    })))));
+
+    @Test
+    void startIsShiftedToTheMinimalMatchingDayOrFallsBackToZeroWithinTheHorizon() {
+        Property.def("DefaultFixedWindowPlanningConstraints.getStart() == startTime + minimal matching day,"
+                + " or startTime unchanged when nothing in the horizon matches")
+                .forAll(START_AND_CRON)
+                .suchThat(startAndCron -> {
+                    ZonedDateTime startTime = startAndCron._1;
+                    Cron cron = startAndCron._2;
+
+                    DefaultFixedWindowPlanningConstraints constraints = buildConstraints(startTime, cron);
+                    long actualDelayDays = ChronoUnit.DAYS.between(startTime, constraints.getStart());
+
+                    Option<Integer> expectedDelayDays = findMinimalMatchingDelay(startTime, cron);
+                    if (expectedDelayDays.isDefined()) {
+                        return actualDelayDays == expectedDelayDays.get()
+                                && ExecutionTime.forCron(cron).isMatch(constraints.getStart());
+                    } else {
+                        // Nothing in the 35-day horizon matches: the documented fallback applies, and the
+                        // resulting start does NOT satisfy the cron - a known limitation of the hardcoded cap,
+                        // not something this test treats as a silent pass-through.
+                        return actualDelayDays == 0;
+                    }
+                })
+                .check()
+                .assertIsSatisfied();
+    }
+
+    // Deterministic complement to the property above: a day-of-month cron that can never match within the
+    // 35-day horizon from this particular start. The 31st only occurs in Jan/Mar/May/Jul/Aug/Oct/Dec, and
+    // starting right after Jan 31 the next occurrence is Mar 31 - 58 days out (28 days left in Feb, plus 30
+    // to get from Mar 1 to Mar 31) - pinning that the fallback is delay 0, not a silently wrong window.
+    @Test
+    void whenNoMatchExistsWithinTheHorizon_thenFallsBackToUnshiftedStartTime() {
+        ZonedDateTime startTime = ZonedDateTime.of(2023, 2, 1, 10, 0, 0, 0, UTC);
+        Cron cron = dayOfMonthCron(0, 0, 10, 31);
+
+        assertThat(findMinimalMatchingDelay(startTime, cron)).isEmpty();
+
+        DefaultFixedWindowPlanningConstraints constraints = buildConstraints(startTime, cron);
+
+        assertThat(constraints.getStart()).isEqualTo(startTime);
+        assertThat(ExecutionTime.forCron(cron).isMatch(constraints.getStart())).isFalse();
+    }
+
+    private static DefaultFixedWindowPlanningConstraints buildConstraints(ZonedDateTime startTime, Cron cron) {
+        return DefaultFixedWindowPlanningConstraints.builder()
+                .withIdentity("job")
+                .withDuration(Duration.ofMinutes(30))
+                .withCarbonIntensityZone("NL")
+                .withCronExpression(cron)
+                .withStartAndEnd(startTime, startTime.plusHours(1))
+                .withFallbackCronExpression(FALLBACK_CRON)
+                .withTimeZoneId(UTC)
+                .build();
+    }
+
+    // Independent oracle: brute-force the same 0..34 day horizon the production code covers (day 0 via
+    // checkStartTime, 1..34 via calculateDelayedDays), returning the smallest matching offset, if any.
+    private static Option<Integer> findMinimalMatchingDelay(ZonedDateTime startTime, Cron cron) {
+        ExecutionTime executionTime = ExecutionTime.forCron(cron);
+        for (int day = 0; day < HORIZON_DAYS; day++) {
+            if (executionTime.isMatch(startTime.plusDays(day))) {
+                return Option.some(day);
+            }
+        }
+        return Option.none();
+    }
+
+    private static Cron dayOfMonthCron(int second, int minute, int hour, int dayOfMonth) {
+        return QUARTZ_PARSER.parse(String.format("%d %d %d %d * ?", second, minute, hour, dayOfMonth));
+    }
+
+    private static Cron dayOfWeekCron(int second, int minute, int hour, String dayOfWeek) {
+        return QUARTZ_PARSER.parse(String.format("%d %d %d ? * %s", second, minute, hour, dayOfWeek));
+    }
+}

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/runtime/impl/TestCarbonIntensityCacheProperties.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/runtime/impl/TestCarbonIntensityCacheProperties.java
@@ -1,0 +1,170 @@
+package io.carbonintensity.executionplanner.runtime.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
+import io.vavr.test.Arbitrary;
+import io.vavr.test.Gen;
+import io.vavr.test.Property;
+
+/**
+ * Property-based tests complementing the example-based tests in {@link TestCarbonIntensityCache}, covering two
+ * invariants of {@link CarbonIntensityCache}:
+ * <ul>
+ * <li>{@link CarbonIntensityCache.Key} equality/hashCode must be consistent with hour-truncation, for any
+ * {@link Instant} and any zone spelling (case/whitespace) - including around a DST fall-back overlap, where a
+ * local hour repeats but the underlying {@link Instant}s remain distinct.</li>
+ * <li>{@link CarbonIntensityCache#computeExpireAfterCreateNanos} must always return a non-negative nanosecond
+ * TTL, even when {@code value.getEnd()} already lies in the past relative to "now": a negative value handed to
+ * Caffeine's custom {@code Expiry} has undefined behaviour.</li>
+ * </ul>
+ *
+ * <p>
+ * See {@code docs/adr/0002-vavr-test-over-jqwik.md} (in carbonintensity-api) for why vavr-test rather than
+ * jqwik is used here.
+ */
+class TestCarbonIntensityCacheProperties {
+
+    private static final ZoneId AMSTERDAM = ZoneId.of("Europe/Amsterdam");
+
+    // A plausible range of instants (roughly the years 2001-2033), same range as the sibling
+    // TestCarbonIntensityJsonParserProperties, rather than the full Instant range.
+    private static final Arbitrary<Instant> INSTANTS = size -> Gen.choose(0L, 2_000_000_000L).map(Instant::ofEpochSecond);
+
+    private static final Arbitrary<String> BASE_ZONES = Arbitrary.of("NL", "BE", "DE", "FR", "GB");
+
+    // Two instants guaranteed to truncate to the same hour: an arbitrary hour start, plus two independent
+    // (possibly different) offsets within [0, 3599] seconds.
+    private static final Arbitrary<Tuple2<Instant, Instant>> SAME_HOUR_INSTANTS = size -> INSTANTS.apply(size)
+            .map(instant -> instant.truncatedTo(ChronoUnit.HOURS))
+            .flatMap(hourStart -> Gen.choose(0, 3599)
+                    .flatMap(offset1 -> Gen.choose(0, 3599)
+                            .map(offset2 -> Tuple.of(hourStart.plusSeconds(offset1), hourStart.plusSeconds(offset2)))));
+
+    // Two instants guaranteed to fall in *different* hours: an hour start, plus a nonzero hour offset (1-24h)
+    // applied to the second one.
+    private static final Arbitrary<Tuple2<Instant, Instant>> DIFFERENT_HOUR_INSTANTS = size -> INSTANTS.apply(size)
+            .map(instant -> instant.truncatedTo(ChronoUnit.HOURS))
+            .flatMap(hourStart -> Gen.choose(1, 24)
+                    .map(hourOffset -> Tuple.of(hourStart, hourStart.plusSeconds(hourOffset * 3600L))));
+
+    // Two spellings of the same zone that Key must treat as identical: any combination of upper/lower case and
+    // surrounding whitespace (Key normalizes via toLowerCase().trim()).
+    private static final Arbitrary<Tuple2<String, String>> EQUIVALENT_ZONE_SPELLINGS = size -> BASE_ZONES.apply(size)
+            .flatMap(base -> Gen.choose(0, 4)
+                    .flatMap(variant1 -> Gen.choose(0, 4)
+                            .map(variant2 -> Tuple.of(zoneVariant(base, variant1), zoneVariant(base, variant2)))));
+
+    private static String zoneVariant(String base, int variant) {
+        return switch (variant) {
+            case 0 -> base;
+            case 1 -> base.toUpperCase();
+            case 2 -> base.toLowerCase();
+            case 3 -> " " + base + " ";
+            case 4 -> "\t" + base.toLowerCase() + "\n";
+            default -> throw new IllegalArgumentException("Unexpected variant: " + variant);
+        };
+    }
+
+    @Test
+    void keysAreEqualWhenInstantsShareAnHourAndZonesAreEquivalentSpellings() {
+        Property.def("Key(t1, z1).equals(Key(t2, z2)) and same hashCode, when t1/t2 truncate to the same hour "
+                + "and z1/z2 are equivalent zone spellings")
+                .forAll(SAME_HOUR_INSTANTS, EQUIVALENT_ZONE_SPELLINGS)
+                .suchThat((instants, zones) -> {
+                    var key1 = new CarbonIntensityCache.Key(instants._1, zones._1);
+                    var key2 = new CarbonIntensityCache.Key(instants._2, zones._2);
+
+                    return key1.equals(key2) && key2.equals(key1) && key1.hashCode() == key2.hashCode();
+                })
+                .check()
+                .assertIsSatisfied();
+    }
+
+    @Test
+    void keysAreNotEqualWhenInstantsFallInDifferentHours() {
+        Property.def("Key(t1, z).equals(Key(t2, z)) is false when t1/t2 truncate to different hours")
+                .forAll(DIFFERENT_HOUR_INSTANTS, BASE_ZONES)
+                .suchThat((instants, zone) -> {
+                    var key1 = new CarbonIntensityCache.Key(instants._1, zone);
+                    var key2 = new CarbonIntensityCache.Key(instants._2, zone);
+
+                    return !key1.equals(key2);
+                })
+                .check()
+                .assertIsSatisfied();
+    }
+
+    // Deterministic complement to the properties above: Key truncates the raw (UTC) Instant, so it is
+    // unaffected by DST - but this pins down that a repeated local hour during the Europe/Amsterdam fall-back
+    // overlap (2025-10-26, clocks go back from 03:00 CEST to 02:00 CET) still produces two distinct Keys,
+    // since the two occurrences of local 02:30 are, in fact, an hour apart in absolute (UTC) time.
+    @Test
+    void keysStayDistinctAcrossTheFallBackOverlapRepeatedLocalHour() {
+        LocalDateTime repeatedLocalTime = LocalDateTime.of(2025, 10, 26, 2, 30);
+        Instant firstOccurrence = ZonedDateTime.of(repeatedLocalTime, AMSTERDAM).withEarlierOffsetAtOverlap().toInstant();
+        Instant secondOccurrence = ZonedDateTime.of(repeatedLocalTime, AMSTERDAM).withLaterOffsetAtOverlap().toInstant();
+
+        // Sanity check on the scenario itself: same local wall-clock time, one absolute hour apart.
+        assertThat(Duration.between(firstOccurrence, secondOccurrence)).isEqualTo(Duration.ofHours(1));
+
+        var key1 = new CarbonIntensityCache.Key(firstOccurrence, "NL");
+        var key2 = new CarbonIntensityCache.Key(secondOccurrence, "NL");
+
+        assertThat(key1).isNotEqualTo(key2);
+        assertThat(key1.hashCode()).isNotEqualTo(key2.hashCode());
+    }
+
+    // Offset (possibly negative) from "now" to the carbon-intensity block's end. Negative means the block
+    // already ended before "now" - e.g. a stale upstream response, or a slow fetch that only completes after
+    // the block it describes has expired - the edge case the existing example-based tests don't cover.
+    private static final Arbitrary<Integer> END_OFFSET_SECONDS = size -> Gen.choose(-200_000, 200_000);
+
+    @Test
+    void expireAfterCreateNanosIsNeverNegativeEvenWhenEndIsAlreadyInThePast() {
+        Property.def("computeExpireAfterCreateNanos(...) >= 0 for any 'now'/end combination")
+                .forAll(INSTANTS, END_OFFSET_SECONDS)
+                .suchThat((now, endOffsetSeconds) -> {
+                    var value = new CarbonIntensity();
+                    value.setData(List.of(BigDecimal.ONE));
+                    value.setEnd(now.plusSeconds(endOffsetSeconds));
+
+                    long nanos = CarbonIntensityCache.computeExpireAfterCreateNanos(value, now, Duration.ofHours(1));
+
+                    return nanos >= 0;
+                })
+                .check()
+                .assertIsSatisfied();
+    }
+
+    @Test
+    void expireAfterCreateNanosIsAlwaysTheEmptyValueTtlWhenDataIsEmpty() {
+        Property.def("computeExpireAfterCreateNanos(...) == emptyValueTTL.toNanos() whenever value.getData() is empty, "
+                + "regardless of 'now' or end")
+                .forAll(INSTANTS, END_OFFSET_SECONDS)
+                .suchThat((now, endOffsetSeconds) -> {
+                    var value = new CarbonIntensity();
+                    value.setData(List.of());
+                    value.setEnd(now.plusSeconds(endOffsetSeconds));
+                    var emptyValueTTL = Duration.ofHours(1);
+
+                    long nanos = CarbonIntensityCache.computeExpireAfterCreateNanos(value, now, emptyValueTTL);
+
+                    return nanos == emptyValueTTL.toNanos();
+                })
+                .check()
+                .assertIsSatisfied();
+    }
+}

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/spi/TestConcurrencySlotTrackerProperties.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/spi/TestConcurrencySlotTrackerProperties.java
@@ -1,0 +1,192 @@
+package io.carbonintensity.executionplanner.spi;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.vavr.Tuple;
+import io.vavr.test.Arbitrary;
+import io.vavr.test.Gen;
+import io.vavr.test.Property;
+
+/**
+ * Model-based property test for {@link ConcurrencySlotTracker}, alongside the example-based tests in
+ * {@link TestConcurrencySlotTracker}.
+ * <p>
+ * {@link ConcurrencySlotTracker}'s three public methods are all serialized per zone under a single internal
+ * lock, so the interesting invariants are not thread-race invariants but <em>sequential state-machine</em>
+ * invariants: they must hold after every single step of an arbitrarily long, arbitrarily ordered sequence of
+ * {@code reserve}/{@code tryReserve}/{@code countOthersAt} calls, regardless of which zones/identities/slots
+ * those calls target. That fits a single-threaded model-based property test: generate a random command
+ * sequence, replay it against a fresh tracker and a plain-map shadow model in lockstep, and check the
+ * invariants after every step rather than only at the end.
+ * <p>
+ * The invariants under test are:
+ * <ul>
+ * <li>(a) each identity occupies at most one slot per zone at any time;</li>
+ * <li>(b) {@code tryReserve} never lets more than {@code maxConcurrentPerSlot} other identities occupy a
+ * slot;</li>
+ * <li>(c) zones never interfere with each other.</li>
+ * </ul>
+ * These are not asserted directly (the tracker exposes no "list current occupants" accessor to check them
+ * against) but indirectly and exhaustively: the shadow model records, per zone, at most one slot per
+ * identity - so by construction it can only ever agree with the real tracker if (a) holds - and after every
+ * step {@link #invariantsHold} cross-checks {@link ConcurrencySlotTracker#countOthersAt} against the model
+ * for every zone/slot/identity combination in play, including an identity that never reserves anything. A
+ * cleanup bug that leaves a stale occupant behind in the wrong slot (e.g. a skipped
+ * {@code previousOccupants.remove}/{@code slots.remove}) or that leaks a reservation across zones would make
+ * some real count exceed the model's, and would be caught by that cross-check on the very step it happens.
+ * (b) is additionally checked directly by comparing {@code tryReserve}'s return value against the model's
+ * own prediction at every step.
+ * <p>
+ * See {@code docs/adr/0002-vavr-test-over-jqwik.md} (in carbonintensity-api) for why vavr-test rather than
+ * jqwik is used here.
+ */
+class TestConcurrencySlotTrackerProperties {
+
+    // A small, deliberately overlapping pool of zones/identities/slots so that a typical generated sequence
+    // produces plenty of collisions (same identity/slot revisited, different identities racing for the same
+    // slot, several identities moving between slots) rather than every call landing on fresh state.
+    private static final List<String> ZONES = List.of("Z1", "Z2");
+    private static final List<String> IDENTITIES = List.of("id-1", "id-2", "id-3", "id-4");
+    // Never targeted by a generated command - exercises the "identity that has never reserved anything"
+    // branch of countOthersAt in the invariant cross-check below.
+    private static final String NEVER_RESERVED_IDENTITY = "id-ghost";
+    private static final List<String> CHECK_IDENTITIES = List.of("id-1", "id-2", "id-3", "id-4", NEVER_RESERVED_IDENTITY);
+    private static final List<Instant> SLOTS = List.of(
+            Instant.parse("2024-08-27T12:00:00Z"),
+            Instant.parse("2024-08-27T13:00:00Z"),
+            Instant.parse("2024-08-27T14:00:00Z"));
+
+    private static final Gen<String> ZONE_GEN = Gen.choose(ZONES);
+    private static final Gen<String> IDENTITY_GEN = Gen.choose(IDENTITIES);
+    private static final Gen<Instant> SLOT_GEN = Gen.choose(SLOTS);
+    private static final Gen<Integer> MAX_CONCURRENT_GEN = Gen.choose(0, 3);
+
+    private static final Gen<Command> RESERVE_GEN = ZONE_GEN
+            .flatMap(zone -> IDENTITY_GEN
+                    .flatMap(identity -> SLOT_GEN
+                            .map(slot -> new Reserve(zone, identity, slot))));
+
+    private static final Gen<Command> TRY_RESERVE_GEN = ZONE_GEN
+            .flatMap(zone -> IDENTITY_GEN
+                    .flatMap(identity -> SLOT_GEN
+                            .flatMap(slot -> MAX_CONCURRENT_GEN
+                                    .map(max -> new TryReserve(zone, identity, slot, max)))));
+
+    private static final Gen<Command> COUNT_OTHERS_AT_GEN = ZONE_GEN
+            .flatMap(zone -> IDENTITY_GEN
+                    .flatMap(identity -> SLOT_GEN
+                            .map(slot -> new CountOthersAt(zone, identity, slot))));
+
+    // Weighted towards tryReserve, since that's the compound check-and-reserve operation where a race or a
+    // cleanup bug would actually be observable; plain reserve and read-only countOthersAt calls are mixed in
+    // so sequences also cover the "fallback always wins" and pure-read cases interleaved with it.
+    private static final Gen<Command> COMMAND_GEN = Gen.frequency(
+            Tuple.of(3, RESERVE_GEN),
+            Tuple.of(5, TRY_RESERVE_GEN),
+            Tuple.of(2, COUNT_OTHERS_AT_GEN));
+
+    private static final Arbitrary<io.vavr.collection.List<Command>> COMMAND_SEQUENCE = Arbitrary.list(COMMAND_GEN.arbitrary());
+
+    @Test
+    void invariantsHoldAfterEveryStepOfAnyCommandSequence() {
+        Property.def("ConcurrencySlotTracker keeps its per-identity/per-zone/limit invariants after every step")
+                .forAll(COMMAND_SEQUENCE)
+                .suchThat(TestConcurrencySlotTrackerProperties::replayAndCheckInvariantsThroughout)
+                .check()
+                .assertIsSatisfied();
+    }
+
+    private static boolean replayAndCheckInvariantsThroughout(io.vavr.collection.List<Command> commands) {
+        ConcurrencySlotTracker tracker = new ConcurrencySlotTracker();
+        // Shadow model: zone -> (identity -> the one slot it currently holds in that zone). Its very shape
+        // enforces invariant (a) - one slot per identity per zone - so agreement with the real tracker below
+        // is only possible if the tracker maintains that invariant too.
+        Map<String, Map<String, Instant>> model = new HashMap<>();
+
+        for (Command command : commands) {
+            if (!applyAndVerify(command, tracker, model)) {
+                return false;
+            }
+            if (!invariantsHold(tracker, model)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean applyAndVerify(Command command, ConcurrencySlotTracker tracker,
+            Map<String, Map<String, Instant>> model) {
+        if (command instanceof Reserve r) {
+            tracker.reserve(r.zone(), r.identity(), r.slot());
+            model.computeIfAbsent(r.zone(), z -> new HashMap<>()).put(r.identity(), r.slot());
+        } else if (command instanceof TryReserve t) {
+            boolean expectedSuccess = countOthersInModel(model, t.zone(), t.identity(), t.slot()) < t.maxConcurrentPerSlot();
+            boolean actualSuccess = tracker.tryReserve(t.zone(), t.identity(), t.slot(), t.maxConcurrentPerSlot());
+            if (actualSuccess != expectedSuccess) {
+                return false;
+            }
+            if (expectedSuccess) {
+                model.computeIfAbsent(t.zone(), z -> new HashMap<>()).put(t.identity(), t.slot());
+            }
+        } else if (command instanceof CountOthersAt c) {
+            int expected = countOthersInModel(model, c.zone(), c.identity(), c.slot());
+            int actual = tracker.countOthersAt(c.zone(), c.identity(), c.slot());
+            if (actual != expected) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // Exhaustively cross-checks the real tracker against the shadow model for every zone/slot/identity
+    // combination in play - not just the ones the just-applied command happened to target - so a stale
+    // occupant left behind in the wrong slot, or a reservation that leaked into the wrong zone, is caught on
+    // the very step it happens rather than only if a later command happens to query that exact spot.
+    private static boolean invariantsHold(ConcurrencySlotTracker tracker, Map<String, Map<String, Instant>> model) {
+        for (String zone : ZONES) {
+            for (Instant slot : SLOTS) {
+                for (String identity : CHECK_IDENTITIES) {
+                    int expected = countOthersInModel(model, zone, identity, slot);
+                    int actual = tracker.countOthersAt(zone, identity, slot);
+                    if (actual != expected) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    private static int countOthersInModel(Map<String, Map<String, Instant>> model, String zone, String identity,
+            Instant slot) {
+        Map<String, Instant> reservationsInZone = model.get(zone);
+        if (reservationsInZone == null) {
+            return 0;
+        }
+        int count = 0;
+        for (Map.Entry<String, Instant> entry : reservationsInZone.entrySet()) {
+            if (!entry.getKey().equals(identity) && entry.getValue().equals(slot)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /** A single call against {@link ConcurrencySlotTracker}, as one step of a generated command sequence. */
+    private sealed interface Command permits Reserve, TryReserve, CountOthersAt {
+    }
+
+    private record Reserve(String zone, String identity, Instant slot) implements Command {
+    }
+
+    private record TryReserve(String zone, String identity, Instant slot, int maxConcurrentPerSlot) implements Command {
+    }
+
+    private record CountOthersAt(String zone, String identity, Instant slot) implements Command {
+    }
+}


### PR DESCRIPTION
## Summary

Nine commits from a broader property-test sweep of the scheduling/execution-planner logic, following on from #274. Each commit adds a vavr-test property test for one class; when the property test found a real bug, it's fixed in the same commit.

- **fix(scheduler): correct fallback cron time for overnight fixed windows** — `GreenScheduledAnnotationParser`'s fallback-cron calculation went negative for an overnight window (e.g. 23:15→02:15), landing the fallback trigger time 12 hours away from the window's actual midpoint instead of inside it. Fixed by wrapping the day-window duration into `[0, 86400)` seconds before halving.
- **fix(execution-planner): make CarbonIntensityPeriod.contains half-open at its upper bound** — `contains(Instant)` treated periods as fully inclusive (`[start, end]`), so the shared boundary between two adjacent, contiguous periods was reported as contained by both at once. Made half-open (`[start, end)`). The only caller already recomputes overlap independently for shortlisted candidates, so this never produced a customer-visible double-count, but it was a real bug in the method's own contract.
- **fix(cache): clamp expireAfterCreate TTL to a non-negative value** — `CarbonIntensityCache`'s Caffeine `Expiry` could be handed a negative nanosecond TTL when a cached entry's end time was already in the past (e.g. a stale entry re-created after a slow upstream fetch) — undefined behavior per Caffeine's contract. Clamped to zero so already-expired data evicts immediately.
- Six more commits add property-test coverage with no bug found: `DefaultFixedWindowPlanningConstraints`'s day-shift fallback, `SkipConcurrentExecutionInvoker`'s concurrency invariant (deterministic, no real threads), `ConcurrencySlotTracker`'s state-machine invariants (model-based), `GreenScheduledAnnotationParser#parseCronExpression`, `DurationFieldParser.parseDuration`, and `Timeslot.getTimeslots`.

## Test plan

- [x] `./mvnw test` — full reactor build, all modules green (core, execution-planner, spring-boot-starter, quarkus/micronaut extensions, integration-tests)
- [x] `./mvnw spotless:check` — clean across all modules
- [x] Each commit's property test independently re-run and verified before bundling onto this branch