### PR TITLE
Add the job decision timeline: unconditional per-job fire history

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,31 @@ running at all (a warning is logged when this happens). This only coordinates jo
 instance - it does not coordinate across multiple instances/replicas of the same application; combine it with
 [ShedLock](#concurrent-executions) if you also run multiple instances.
 
+### Logging
+Not sure whether (or when) a job will actually run? Every real fire is logged at `DEBUG` on
+`io.carbonintensity.scheduler.runtime.SimpleScheduler`, with a short reason (a green slot was found, or a fallback
+to the job's configured cron/plain interval spacing was used):
+
+```properties
+# Spring Boot (application.properties)
+logging.level.io.carbonintensity.scheduler.runtime.SimpleScheduler=DEBUG
+```
+
+```properties
+# Quarkus (application.properties)
+quarkus.log.category."io.carbonintensity.scheduler.runtime.SimpleScheduler".level=DEBUG
+```
+
+Every log line emitted while a job is running also carries its `identity` in the [SLF4J MDC](https://www.slf4j.org/manual.html#mdc),
+so a logging backend that renders MDC (most JSON/structured formatters do) can filter or group by it without any
+extra configuration.
+
+Beyond logging, every job's history of fired decisions (when, which strategy, and why) is available programmatically
+as its **decision timeline** - see `DecisionTimelineStore`/`DecisionTimelineEntry` (`io.carbonintensity.scheduler.observability`)
+and `Scheduler.EventListener#jobDecisionRecorded`. This is always on, for every job, no annotation required. The
+default storage is in-memory only (bounded by both a retention window and an entry-count cap, both configurable on
+`SchedulerConfig`) - plug in your own `DecisionTimelineStore` implementation if you need it to survive a restart.
+
 ## Acknowledgements
 The maven project structure and all documentation regarding contribution is adapted from
 what the [Quarkus](https://github.com/quarkusio/quarkus) community has created. Further acknowledgements can be found in the [NOTICE](NOTICE) file

--- a/README.md
+++ b/README.md
@@ -259,9 +259,9 @@ logging.level.io.carbonintensity.scheduler.runtime.SimpleScheduler=DEBUG
 quarkus.log.category."io.carbonintensity.scheduler.runtime.SimpleScheduler".level=DEBUG
 ```
 
-Every log line emitted while a job is running also carries its `identity` in the [SLF4J MDC](https://www.slf4j.org/manual.html#mdc),
-so a logging backend that renders MDC (most JSON/structured formatters do) can filter or group by it without any
-extra configuration.
+Every log line emitted while a job is running also carries its `identity`, `strategy` and `zone` in the
+[SLF4J MDC](https://www.slf4j.org/manual.html#mdc), so a logging backend that renders MDC (most JSON/structured
+formatters do) can filter or group by them without any extra configuration.
 
 Beyond logging, every job's history of fired decisions (when, which strategy, and why) is available programmatically
 as its **decision timeline** - see `DecisionTimelineStore`/`DecisionTimelineEntry` (`io.carbonintensity.scheduler.observability`)

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -77,8 +77,11 @@
             <artifactId>parsson</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
+            <!-- Not slf4j-simple: its MDC adapter is a no-op, and DecisionTimelineWiringTest needs a real one to
+                 verify the identity MDC key is actually populated during a job's invocation. -->
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.5.18</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/src/main/java/io/carbonintensity/scheduler/Scheduler.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/Scheduler.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import io.carbonintensity.executionplanner.spi.CarbonIntensityPlanner;
+import io.carbonintensity.scheduler.observability.DecisionTimelineEntry;
 
 /**
  * A basic scheduler.
@@ -106,6 +107,13 @@ public interface Scheduler {
         }
 
         default void jobExecutionSuccessful(ScheduledExecution execution) {
+        }
+
+        /**
+         * Fired every time a job's decision timeline gains a new entry - i.e. every real fire of a
+         * {@link GreenScheduled} or programmatic job, unconditionally. See {@link DecisionTimelineEntry}.
+         */
+        default void jobDecisionRecorded(Trigger trigger, DecisionTimelineEntry entry) {
         }
 
         default void schedulerPaused() {

--- a/core/src/main/java/io/carbonintensity/scheduler/Trigger.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/Trigger.java
@@ -1,7 +1,6 @@
 package io.carbonintensity.scheduler;
 
 import java.time.Instant;
-import java.util.Optional;
 
 import io.carbonintensity.scheduler.observability.DecisionStrategy;
 
@@ -55,12 +54,11 @@ public interface Trigger {
     }
 
     /**
-     * @return the top-level {@link DecisionStrategy} this trigger is configured with, or {@link Optional#empty()}
-     *         for a trigger that makes no carbon-aware decision of its own (e.g. an internal, non-adopter-facing
-     *         trigger)
+     * @return the top-level {@link DecisionStrategy} this trigger is configured with, or {@code null} for a
+     *         trigger that makes no carbon-aware decision of its own (e.g. an internal, non-adopter-facing trigger)
      */
-    default Optional<DecisionStrategy> getDecisionStrategy() {
-        return Optional.empty();
+    default DecisionStrategy getDecisionStrategy() {
+        return null;
     }
 
     /**

--- a/core/src/main/java/io/carbonintensity/scheduler/Trigger.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/Trigger.java
@@ -1,6 +1,9 @@
 package io.carbonintensity.scheduler;
 
 import java.time.Instant;
+import java.util.Optional;
+
+import io.carbonintensity.scheduler.observability.DecisionStrategy;
 
 /**
  * Trigger is bound to a scheduled job.
@@ -48,6 +51,23 @@ public interface Trigger {
      * @return the method description or {@code null} for a trigger of a programmatically added job
      */
     default String getMethodDescription() {
+        return null;
+    }
+
+    /**
+     * @return the top-level {@link DecisionStrategy} this trigger is configured with, or {@link Optional#empty()}
+     *         for a trigger that makes no carbon-aware decision of its own (e.g. an internal, non-adopter-facing
+     *         trigger)
+     */
+    default Optional<DecisionStrategy> getDecisionStrategy() {
+        return Optional.empty();
+    }
+
+    /**
+     * @return the carbon-intensity zone this trigger is configured with, or {@code null} if not applicable
+     * @see GreenScheduled#carbonIntensityZone()
+     */
+    default String getCarbonIntensityZone() {
         return null;
     }
 

--- a/core/src/main/java/io/carbonintensity/scheduler/Trigger.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/Trigger.java
@@ -54,15 +54,18 @@ public interface Trigger {
     }
 
     /**
-     * @return the top-level {@link DecisionStrategy} this trigger is configured with, or {@code null} for a
-     *         trigger that makes no carbon-aware decision of its own (e.g. an internal, non-adopter-facing trigger)
+     * @return the top-level {@link DecisionStrategy} this trigger is
+     *         configured with, or {@code null} for a trigger that makes no
+     *         carbon-aware decision of its own (e.g. an internal,
+     *         non-adopter-facing trigger)
      */
     default DecisionStrategy getDecisionStrategy() {
         return null;
     }
 
     /**
-     * @return the carbon-intensity zone this trigger is configured with, or {@code null} if not applicable
+     * @return the carbon-intensity zone this trigger is configured with, or
+     *         {@code null} if not applicable
      * @see GreenScheduled#carbonIntensityZone()
      */
     default String getCarbonIntensityZone() {

--- a/core/src/main/java/io/carbonintensity/scheduler/observability/DecisionReason.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/observability/DecisionReason.java
@@ -1,25 +1,29 @@
 package io.carbonintensity.scheduler.observability;
 
 /**
- * Why a particular moment was chosen for a job's {@link DecisionTimelineEntry}, distinguishing a genuinely
- * carbon-aware choice from a fallback the job's {@link DecisionStrategy} took when no carbon-aware slot was
- * available. Kept to what the scheduler can actually distinguish today - not a speculative superset.
+ * Why a moment was chosen for a job's {@link DecisionTimelineEntry}: a
+ * genuinely carbon-aware choice, or a fallback the job's
+ * {@link DecisionStrategy} took when no carbon-aware slot was available.
+ * Kept to what the scheduler can actually distinguish today - not a
+ * speculative superset.
  */
 public enum DecisionReason {
 
     /**
-     * A carbon-aware planner found and chose the greenest available slot within the job's configured constraints.
+     * A carbon-aware planner found and chose the greenest available slot
+     * within the job's configured constraints.
      */
     GREENEST_AVAILABLE_SLOT("the greenest available slot was chosen"),
 
     /**
-     * A {@code fixedWindow()} job found no green window and fell back to its configured fallback cron expression.
+     * A {@code fixedWindow()} job found no green window and fell back to its
+     * configured fallback cron expression.
      */
     FALLBACK_TO_CONFIGURED_CRON("no green window was found - fell back to the configured cron schedule"),
 
     /**
-     * A {@code successive()} job found no green slot and fell back to plain interval spacing (the average of its
-     * minimum/maximum gap).
+     * A {@code successive()} job found no green slot and fell back to plain
+     * interval spacing (the average of its minimum/maximum gap).
      */
     FALLBACK_TO_PLAIN_INTERVAL("no green slot was found - fell back to plain interval spacing");
 
@@ -30,7 +34,8 @@ public enum DecisionReason {
     }
 
     /**
-     * @return a short, human-readable explanation suitable for direct use in log messages or documentation examples
+     * @return a short, human-readable explanation suitable for direct use
+     *         in log messages or documentation examples
      */
     public String label() {
         return label;

--- a/core/src/main/java/io/carbonintensity/scheduler/observability/DecisionReason.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/observability/DecisionReason.java
@@ -1,0 +1,44 @@
+package io.carbonintensity.scheduler.observability;
+
+/**
+ * Why a particular moment was chosen for a job's {@link DecisionTimelineEntry}, distinguishing a genuinely
+ * carbon-aware choice from a fallback the job's {@link DecisionStrategy} took when no carbon-aware slot was
+ * available. Kept to what the scheduler can actually distinguish today - not a speculative superset.
+ */
+public enum DecisionReason {
+
+    /**
+     * A carbon-aware planner found and chose the greenest available slot within the job's configured constraints.
+     */
+    GREENEST_AVAILABLE_SLOT("the greenest available slot was chosen"),
+
+    /**
+     * A {@code fixedWindow()} job found no green window and fell back to its configured fallback cron expression.
+     */
+    FALLBACK_TO_CONFIGURED_CRON("no green window was found - fell back to the configured cron schedule"),
+
+    /**
+     * A {@code successive()} job found no green slot and fell back to plain interval spacing (the average of its
+     * minimum/maximum gap).
+     */
+    FALLBACK_TO_PLAIN_INTERVAL("no green slot was found - fell back to plain interval spacing");
+
+    private final String label;
+
+    DecisionReason(String label) {
+        this.label = label;
+    }
+
+    /**
+     * @return a short, human-readable explanation suitable for direct use in log messages or documentation examples
+     */
+    public String label() {
+        return label;
+    }
+
+    @Override
+    public String toString() {
+        return label;
+    }
+
+}

--- a/core/src/main/java/io/carbonintensity/scheduler/observability/DecisionStrategy.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/observability/DecisionStrategy.java
@@ -1,0 +1,26 @@
+package io.carbonintensity.scheduler.observability;
+
+/**
+ * Which top-level scheduling strategy made a job's decision, recorded on every {@link DecisionTimelineEntry}.
+ * <p>
+ * These are the only two adopter-facing strategies a {@link io.carbonintensity.scheduler.GreenScheduled} job (or a
+ * programmatic job) can be configured with - the internal cron/plain-interval mechanisms a job falls back to when no
+ * carbon-aware slot is available are not separate strategies of their own, just a {@link DecisionReason} under
+ * whichever of these two the job is actually configured as.
+ */
+public enum DecisionStrategy {
+
+    /**
+     * The job is configured with {@code fixedWindow()} - a carbon-aware slot within a daily window, falling back to
+     * a configured cron expression when none is available.
+     */
+    FIXED_WINDOW,
+
+    /**
+     * The job is configured with {@code successive()} - a carbon-aware slot honoring a minimum/maximum gap since the
+     * last execution, falling back to plain interval spacing when none is available. Programmatic jobs (
+     * {@link io.carbonintensity.scheduler.Scheduler#newJob}) are always this strategy.
+     */
+    SUCCESSIVE
+
+}

--- a/core/src/main/java/io/carbonintensity/scheduler/observability/DecisionStrategy.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/observability/DecisionStrategy.java
@@ -1,25 +1,28 @@
 package io.carbonintensity.scheduler.observability;
 
 /**
- * Which top-level scheduling strategy made a job's decision, recorded on every {@link DecisionTimelineEntry}.
+ * Which top-level strategy made a job's decision, recorded on every
+ * {@link DecisionTimelineEntry}.
  * <p>
- * These are the only two adopter-facing strategies a {@link io.carbonintensity.scheduler.GreenScheduled} job (or a
- * programmatic job) can be configured with - the internal cron/plain-interval mechanisms a job falls back to when no
- * carbon-aware slot is available are not separate strategies of their own, just a {@link DecisionReason} under
- * whichever of these two the job is actually configured as.
+ * The only two adopter-facing strategies a job (scheduled or programmatic)
+ * can be configured with. Internal cron/plain-interval fallbacks aren't
+ * separate strategies - just a {@link DecisionReason} under one of these two.
  */
 public enum DecisionStrategy {
 
     /**
-     * The job is configured with {@code fixedWindow()} - a carbon-aware slot within a daily window, falling back to
-     * a configured cron expression when none is available.
+     * The job is configured with {@code fixedWindow()} - a carbon-aware slot
+     * within a daily window, falling back to a configured cron expression
+     * when none is available.
      */
     FIXED_WINDOW,
 
     /**
-     * The job is configured with {@code successive()} - a carbon-aware slot honoring a minimum/maximum gap since the
-     * last execution, falling back to plain interval spacing when none is available. Programmatic jobs (
-     * {@link io.carbonintensity.scheduler.Scheduler#newJob}) are always this strategy.
+     * The job is configured with {@code successive()} - a carbon-aware slot
+     * honoring a minimum/maximum gap since the last execution, falling back
+     * to plain interval spacing when none is available. Programmatic jobs
+     * ({@link io.carbonintensity.scheduler.Scheduler#newJob}) are always
+     * this strategy.
      */
     SUCCESSIVE
 

--- a/core/src/main/java/io/carbonintensity/scheduler/observability/DecisionTimelineEntry.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/observability/DecisionTimelineEntry.java
@@ -5,22 +5,12 @@ import java.util.Objects;
 import java.util.OptionalDouble;
 
 /**
- * One recorded firing of a job on its {@code DecisionTimeline}: when it fired, which top-level
- * {@link DecisionStrategy} made the decision, why that particular moment was chosen, and - when available - the
- * carbon-intensity value in effect at that moment.
- * <p>
- * {@code fireTime} is an {@link Instant}, not a {@link java.time.ZonedDateTime} - which zone to render it in is a
- * display concern (a log line, a docs example), not something to bake into the stored data, consistent with
- * {@code CarbonImpactResult}.
- * <p>
- * {@code intensityValue} is genuinely absent for some {@link DecisionReason}s - a plain fallback (cron or interval
- * spacing) isn't driven by a carbon-intensity value at all, so this is never a sentinel like {@code -1} or
- * {@code NaN}, always a real absence.
+ * One firing of a job: when, why, and (when known) the carbon intensity.
  *
  * @param fireTime when the job actually fired
  * @param strategy which top-level strategy the job is configured with
  * @param reason why this particular moment was chosen
- * @param intensityValue the carbon-intensity value in effect at {@code fireTime}, when known
+ * @param intensityValue the carbon intensity at {@code fireTime}, when known
  */
 public record DecisionTimelineEntry(Instant fireTime, DecisionStrategy strategy, DecisionReason reason,
         OptionalDouble intensityValue) {
@@ -30,6 +20,28 @@ public record DecisionTimelineEntry(Instant fireTime, DecisionStrategy strategy,
         Objects.requireNonNull(strategy, "Strategy cannot be null");
         Objects.requireNonNull(reason, "Reason cannot be null");
         Objects.requireNonNull(intensityValue, "IntensityValue cannot be null - use OptionalDouble.empty()");
+    }
+
+    /**
+     * An {@link Instant}, not a {@link java.time.ZonedDateTime} - which zone
+     * to render it in is a display concern (a log line, a docs example), not
+     * something to bake into the stored data, consistent with
+     * {@code CarbonImpactResult}.
+     */
+    @Override
+    public Instant fireTime() {
+        return fireTime;
+    }
+
+    /**
+     * Genuinely absent for some {@link DecisionReason}s: a plain fallback
+     * (cron or interval spacing) isn't driven by a carbon-intensity value at
+     * all, so this is never a sentinel like {@code -1} or {@code NaN} -
+     * always a real absence.
+     */
+    @Override
+    public OptionalDouble intensityValue() {
+        return intensityValue;
     }
 
 }

--- a/core/src/main/java/io/carbonintensity/scheduler/observability/DecisionTimelineEntry.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/observability/DecisionTimelineEntry.java
@@ -1,0 +1,35 @@
+package io.carbonintensity.scheduler.observability;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.OptionalDouble;
+
+/**
+ * One recorded firing of a job on its {@code DecisionTimeline}: when it fired, which top-level
+ * {@link DecisionStrategy} made the decision, why that particular moment was chosen, and - when available - the
+ * carbon-intensity value in effect at that moment.
+ * <p>
+ * {@code fireTime} is an {@link Instant}, not a {@link java.time.ZonedDateTime} - which zone to render it in is a
+ * display concern (a log line, a docs example), not something to bake into the stored data, consistent with
+ * {@link CarbonImpactResult#computedAt()}.
+ * <p>
+ * {@code intensityValue} is genuinely absent for some {@link DecisionReason}s - a plain fallback (cron or interval
+ * spacing) isn't driven by a carbon-intensity value at all, so this is never a sentinel like {@code -1} or
+ * {@code NaN}, always a real absence.
+ *
+ * @param fireTime when the job actually fired
+ * @param strategy which top-level strategy the job is configured with
+ * @param reason why this particular moment was chosen
+ * @param intensityValue the carbon-intensity value in effect at {@code fireTime}, when known
+ */
+public record DecisionTimelineEntry(Instant fireTime, DecisionStrategy strategy, DecisionReason reason,
+        OptionalDouble intensityValue) {
+
+    public DecisionTimelineEntry {
+        Objects.requireNonNull(fireTime, "FireTime cannot be null");
+        Objects.requireNonNull(strategy, "Strategy cannot be null");
+        Objects.requireNonNull(reason, "Reason cannot be null");
+        Objects.requireNonNull(intensityValue, "IntensityValue cannot be null - use OptionalDouble.empty()");
+    }
+
+}

--- a/core/src/main/java/io/carbonintensity/scheduler/observability/DecisionTimelineEntry.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/observability/DecisionTimelineEntry.java
@@ -11,7 +11,7 @@ import java.util.OptionalDouble;
  * <p>
  * {@code fireTime} is an {@link Instant}, not a {@link java.time.ZonedDateTime} - which zone to render it in is a
  * display concern (a log line, a docs example), not something to bake into the stored data, consistent with
- * {@link CarbonImpactResult#computedAt()}.
+ * {@code CarbonImpactResult}.
  * <p>
  * {@code intensityValue} is genuinely absent for some {@link DecisionReason}s - a plain fallback (cron or interval
  * spacing) isn't driven by a carbon-intensity value at all, so this is never a sentinel like {@code -1} or

--- a/core/src/main/java/io/carbonintensity/scheduler/observability/DecisionTimelineStore.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/observability/DecisionTimelineStore.java
@@ -2,36 +2,33 @@ package io.carbonintensity.scheduler.observability;
 
 import java.util.List;
 
-import io.carbonintensity.scheduler.runtime.InMemoryDecisionTimelineStore;
-import io.carbonintensity.scheduler.runtime.SchedulerConfig;
-
 /**
- * Pluggable, retained storage for every job's decision timeline - answering "why was this job shifted / is this a
- * black box" (unconditionally, for every {@link io.carbonintensity.scheduler.GreenScheduled} and programmatic job,
- * no opt-in required).
- * <p>
- * This is an SPI, the same override-hook shape as {@code CarbonIntensityApi} on
- * {@link SchedulerConfig#setCarbonIntensityApi}: the default, {@link InMemoryDecisionTimelineStore}, keeps entries
- * purely in memory, pruned by {@link SchedulerConfig#getDecisionTimelineRetentionDays()} and
- * {@link SchedulerConfig#getDecisionTimelineMaxEntriesPerJob()} - lost on restart, and bounded regardless of how
- * long the process runs. A consumer that needs the timeline to survive a restart, or to keep more than the default
- * in-memory retention, can implement this interface against their own datastore and register it via
- * {@link SchedulerConfig#setDecisionTimelineStore}.
- * <p>
- * Unlike {@code CarbonImpactHistoryStore} (a short-lived, record-then-remove staging area for the daily
- * carbon-impact batch), this store is a long-lived, retained ledger - retention/eviction is this store's own
- * internal responsibility, not driven by an external process, so there is deliberately no {@code remove} method.
+ * Pluggable, retained storage for every job's decision timeline - answering
+ * "why was this job shifted / is this a black box" unconditionally, for
+ * every {@link io.carbonintensity.scheduler.GreenScheduled} and
+ * programmatic job, no opt-in required. Unlike
+ * {@code CarbonImpactHistoryStore} (short-lived, record-then-remove), this
+ * is a long-lived ledger - eviction is its own job, no {@code remove} method.
  */
 public interface DecisionTimelineStore {
 
     /**
-     * Records one new decision for {@code identity}. Implementations are responsible for their own retention/
-     * eviction policy.
+     * Records one new decision for {@code identity}. This is an SPI, the
+     * same override-hook shape as {@code CarbonIntensityApi} on
+     * {@code SchedulerConfig#setCarbonIntensityApi} - the default,
+     * {@code InMemoryDecisionTimelineStore}, keeps entries in memory,
+     * pruned by the retention-days/max-entries config on
+     * {@code SchedulerConfig}. Implementations own their own eviction.
      */
     void record(String identity, DecisionTimelineEntry entry);
 
     /**
-     * @return an immutable snapshot of the entries currently retained for {@code identity}, oldest first
+     * A consumer needing the timeline to survive a restart, or to retain
+     * more than the in-memory default, can implement and register this
+     * via {@code SchedulerConfig#setDecisionTimelineStore}.
+     *
+     * @return an immutable snapshot of the entries retained for
+     *         {@code identity}, oldest first
      */
     List<DecisionTimelineEntry> entriesFor(String identity);
 

--- a/core/src/main/java/io/carbonintensity/scheduler/observability/DecisionTimelineStore.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/observability/DecisionTimelineStore.java
@@ -1,0 +1,38 @@
+package io.carbonintensity.scheduler.observability;
+
+import java.util.List;
+
+import io.carbonintensity.scheduler.runtime.InMemoryDecisionTimelineStore;
+import io.carbonintensity.scheduler.runtime.SchedulerConfig;
+
+/**
+ * Pluggable, retained storage for every job's decision timeline - answering "why was this job shifted / is this a
+ * black box" (unconditionally, for every {@link io.carbonintensity.scheduler.GreenScheduled} and programmatic job,
+ * no opt-in required).
+ * <p>
+ * This is an SPI, the same override-hook shape as {@code CarbonIntensityApi} on
+ * {@link SchedulerConfig#setCarbonIntensityApi}: the default, {@link InMemoryDecisionTimelineStore}, keeps entries
+ * purely in memory, pruned by {@link SchedulerConfig#getDecisionTimelineRetentionDays()} and
+ * {@link SchedulerConfig#getDecisionTimelineMaxEntriesPerJob()} - lost on restart, and bounded regardless of how
+ * long the process runs. A consumer that needs the timeline to survive a restart, or to keep more than the default
+ * in-memory retention, can implement this interface against their own datastore and register it via
+ * {@link SchedulerConfig#setDecisionTimelineStore}.
+ * <p>
+ * Unlike {@code CarbonImpactHistoryStore} (a short-lived, record-then-remove staging area for the daily
+ * carbon-impact batch), this store is a long-lived, retained ledger - retention/eviction is this store's own
+ * internal responsibility, not driven by an external process, so there is deliberately no {@code remove} method.
+ */
+public interface DecisionTimelineStore {
+
+    /**
+     * Records one new decision for {@code identity}. Implementations are responsible for their own retention/
+     * eviction policy.
+     */
+    void record(String identity, DecisionTimelineEntry entry);
+
+    /**
+     * @return an immutable snapshot of the entries currently retained for {@code identity}, oldest first
+     */
+    List<DecisionTimelineEntry> entriesFor(String identity);
+
+}

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/DecisionOutcome.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/DecisionOutcome.java
@@ -1,0 +1,39 @@
+package io.carbonintensity.scheduler.runtime;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+import java.util.OptionalDouble;
+
+import io.carbonintensity.executionplanner.spi.PlannedExecution;
+import io.carbonintensity.scheduler.observability.DecisionReason;
+
+/**
+ * What a trigger decided on a single {@code evaluate()} call that led to a real fire: why this particular moment
+ * was chosen, and the carbon-intensity value behind that choice, when one was actually known.
+ * <p>
+ * Deliberately not public API - {@link io.carbonintensity.scheduler.observability.DecisionTimelineEntry} is the
+ * public-facing shape this feeds into. The two fields are always constructed together, atomically: a trigger that
+ * mutated a reason field and an intensity-value field independently could fall back from a carbon-aware fire to a
+ * plain cron/interval one and leave the previous, unrelated fire's real intensity value attached to the new
+ * fallback reason. {@link #from(PlannedExecution, DecisionReason)} covers the carbon-aware path; fallback triggers
+ * construct a {@code DecisionOutcome} directly, always pairing their reason with {@link OptionalDouble#empty()} -
+ * never an inherited value.
+ */
+record DecisionOutcome(DecisionReason reason, OptionalDouble intensityValue) {
+
+    DecisionOutcome {
+        Objects.requireNonNull(reason, "Reason cannot be null");
+        Objects.requireNonNull(intensityValue, "IntensityValue cannot be null - use OptionalDouble.empty()");
+    }
+
+    /**
+     * Pulls the intensity straight from the {@link PlannedExecution} the planner already built for this fire,
+     * rather than re-deriving it or leaving it to be filled in separately.
+     */
+    static DecisionOutcome from(PlannedExecution plannedExecution, DecisionReason reason) {
+        Objects.requireNonNull(plannedExecution, "PlannedExecution cannot be null");
+        BigDecimal intensity = plannedExecution.intensityValue().orElse(null);
+        return new DecisionOutcome(reason,
+                intensity == null ? OptionalDouble.empty() : OptionalDouble.of(intensity.doubleValue()));
+    }
+}

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/DecisionOutcome.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/DecisionOutcome.java
@@ -8,27 +8,32 @@ import io.carbonintensity.executionplanner.spi.PlannedExecution;
 import io.carbonintensity.scheduler.observability.DecisionReason;
 
 /**
- * What a trigger decided on a single {@code evaluate()} call that led to a real fire: why this particular moment
- * was chosen, and the carbon-intensity value behind that choice, when one was actually known.
+ * What a trigger decided on a single {@code evaluate()} call that led to a
+ * real fire: why this moment was chosen, and the carbon-intensity value
+ * behind it, when known.
  * <p>
- * Deliberately not public API - {@link io.carbonintensity.scheduler.observability.DecisionTimelineEntry} is the
- * public-facing shape this feeds into. The two fields are always constructed together, atomically: a trigger that
- * mutated a reason field and an intensity-value field independently could fall back from a carbon-aware fire to a
- * plain cron/interval one and leave the previous, unrelated fire's real intensity value attached to the new
- * fallback reason. {@link #from(PlannedExecution, DecisionReason)} covers the carbon-aware path; fallback triggers
- * construct a {@code DecisionOutcome} directly, always pairing their reason with {@link OptionalDouble#empty()} -
- * never an inherited value.
+ * Deliberately not public API - the public-facing shape this feeds into is
+ * {@link io.carbonintensity.scheduler.observability.DecisionTimelineEntry}.
  */
 record DecisionOutcome(DecisionReason reason, OptionalDouble intensityValue) {
 
+    /**
+     * Constructed atomically on purpose: mutating {@code reason} and
+     * {@code intensityValue} independently could let a fallback
+     * (cron/interval) fire keep a stale value left over from a prior
+     * carbon-aware fire.
+     */
     DecisionOutcome {
         Objects.requireNonNull(reason, "Reason cannot be null");
         Objects.requireNonNull(intensityValue, "IntensityValue cannot be null - use OptionalDouble.empty()");
     }
 
     /**
-     * Pulls the intensity straight from the {@link PlannedExecution} the planner already built for this fire,
-     * rather than re-deriving it or leaving it to be filled in separately.
+     * Pulls the intensity straight from the {@link PlannedExecution} already
+     * built for this fire, rather than re-deriving it separately. Fallback
+     * triggers build a {@code DecisionOutcome} directly instead, always
+     * pairing their reason with {@link OptionalDouble#empty()} - never an
+     * inherited value.
      */
     static DecisionOutcome from(PlannedExecution plannedExecution, DecisionReason reason) {
         Objects.requireNonNull(plannedExecution, "PlannedExecution cannot be null");

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/Events.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/Events.java
@@ -3,6 +3,7 @@ package io.carbonintensity.scheduler.runtime;
 import io.carbonintensity.scheduler.ScheduledExecution;
 import io.carbonintensity.scheduler.Scheduler;
 import io.carbonintensity.scheduler.Trigger;
+import io.carbonintensity.scheduler.observability.DecisionTimelineEntry;
 
 /**
  * Utility class for firing events related to job execution and scheduler state changes.
@@ -22,6 +23,7 @@ import io.carbonintensity.scheduler.Trigger;
  * <li>Job paused</li>
  * <li>Job resumed</li>
  * <li>Job execution skipped</li>
+ * <li>Job decision recorded</li>
  * </ul>
  * </p>
  *
@@ -83,6 +85,12 @@ public final class Events {
     void fireJobExecutionSkipped(ScheduledExecution execution, String details) {
         for (Scheduler.EventListener listener : simpleScheduler.getEventListeners()) {
             listener.jobExecutionSkipped(execution, details);
+        }
+    }
+
+    void fireJobDecisionRecorded(Trigger trigger, DecisionTimelineEntry entry) {
+        for (Scheduler.EventListener listener : simpleScheduler.getEventListeners()) {
+            listener.jobDecisionRecorded(trigger, entry);
         }
     }
 }

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/InMemoryDecisionTimelineStore.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/InMemoryDecisionTimelineStore.java
@@ -15,12 +15,12 @@ import io.carbonintensity.scheduler.observability.DecisionTimelineEntry;
 import io.carbonintensity.scheduler.observability.DecisionTimelineStore;
 
 /**
- * The default {@link DecisionTimelineStore}: entries kept purely in memory, lost on restart, bounded per job by
- * both a retention window and a hard entry-count cap - whichever is hit first evicts the oldest entries.
+ * The default {@link DecisionTimelineStore}: entries kept purely in
+ * memory, lost on restart, bounded per job by a retention window and a
+ * hard entry-count cap - whichever is hit first evicts the oldest entries.
  * <p>
- * Unlike {@code InMemoryCarbonImpactHistoryStore} (which relies entirely on an external batch process removing
- * processed windows, with no cap of its own), this store must self-prune: it is a long-lived, always-growing ledger
- * with no external remover.
+ * Unlike {@code InMemoryCarbonImpactHistoryStore} (an external batch
+ * process removes its processed windows), this store must self-prune.
  */
 public final class InMemoryDecisionTimelineStore implements DecisionTimelineStore {
 
@@ -51,17 +51,11 @@ public final class InMemoryDecisionTimelineStore implements DecisionTimelineStor
     }
 
     /**
-     * One job's decision entries, kept sorted by {@code fireTime}. Synchronized rather than a lock-free structure:
-     * recording happens at most once per second per job (driven by the scheduler's own trigger-check tick), so
-     * contention is a non-issue and a plain {@link ArrayList} behind a monitor is simpler to reason about than a
-     * concurrent alternative.
-     * <p>
-     * {@link DecisionTimelineStore#record} carries no ordering precondition on the caller, so entries are inserted
-     * at their sorted position rather than always appended - age-based eviction only ever inspects the front of the
-     * list, and that is only correct if the front is always the true oldest entry, regardless of arrival order.
-     * {@link SimpleScheduler} itself only ever calls {@code record} in fireTime order, so this is belt-and-braces
-     * for a default implementation sitting behind a pluggable SPI, not a fix for an observed problem - see
-     * {@code staysCorrectWhenEntriesArriveOutOfOrder} for the guarantee this preserves.
+     * One job's decision entries, kept sorted by {@code fireTime}.
+     * Synchronized rather than lock-free: recording happens at most once
+     * per second per job (the scheduler's own trigger-check tick), so
+     * contention is a non-issue and a plain {@link ArrayList} behind a
+     * monitor is simpler to reason about than a concurrent alternative.
      */
     private static final class Timeline {
 
@@ -70,6 +64,14 @@ public final class InMemoryDecisionTimelineStore implements DecisionTimelineStor
 
         private final List<DecisionTimelineEntry> entries = new ArrayList<>();
 
+        /**
+         * {@link DecisionTimelineStore#record} has no ordering precondition,
+         * so entries go in at their sorted position, not appended - eviction
+         * only inspects the front, correct only if that's always the true
+         * oldest entry. {@link SimpleScheduler} only calls this in fireTime
+         * order already, so this is belt-and-braces, not a fix for an
+         * observed bug - see {@code staysCorrectWhenEntriesArriveOutOfOrder}.
+         */
         synchronized void record(DecisionTimelineEntry entry, Instant cutoff, int maxEntries) {
             int insertionPoint = Collections.binarySearch(entries, entry, BY_FIRE_TIME);
             entries.add(insertionPoint >= 0 ? insertionPoint : -insertionPoint - 1, entry);

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/InMemoryDecisionTimelineStore.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/InMemoryDecisionTimelineStore.java
@@ -60,7 +60,8 @@ public final class InMemoryDecisionTimelineStore implements DecisionTimelineStor
      * at their sorted position rather than always appended - age-based eviction only ever inspects the front of the
      * list, and that is only correct if the front is always the true oldest entry, regardless of arrival order.
      * {@link SimpleScheduler} itself only ever calls {@code record} in fireTime order, so this is belt-and-braces
-     * for a default implementation sitting behind a pluggable SPI, not a fix for an observed problem.
+     * for a default implementation sitting behind a pluggable SPI, not a fix for an observed problem - see
+     * {@code staysCorrectWhenEntriesArriveOutOfOrder} for the guarantee this preserves.
      */
     private static final class Timeline {
 

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/InMemoryDecisionTimelineStore.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/InMemoryDecisionTimelineStore.java
@@ -1,0 +1,76 @@
+package io.carbonintensity.scheduler.runtime;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import io.carbonintensity.scheduler.observability.DecisionTimelineEntry;
+import io.carbonintensity.scheduler.observability.DecisionTimelineStore;
+
+/**
+ * The default {@link DecisionTimelineStore}: entries kept purely in memory, lost on restart, bounded per job by
+ * both a retention window and a hard entry-count cap - whichever is hit first evicts the oldest entries.
+ * <p>
+ * Unlike {@code InMemoryCarbonImpactHistoryStore} (which relies entirely on an external batch process removing
+ * processed windows, with no cap of its own), this store must self-prune: it is a long-lived, always-growing ledger
+ * with no external remover.
+ */
+public final class InMemoryDecisionTimelineStore implements DecisionTimelineStore {
+
+    private final Clock clock;
+    private final Duration retention;
+    private final int maxEntriesPerJob;
+    private final ConcurrentMap<String, Timeline> timelinesByIdentity = new ConcurrentHashMap<>();
+
+    public InMemoryDecisionTimelineStore(Clock clock, Duration retention, int maxEntriesPerJob) {
+        this.clock = Objects.requireNonNull(clock, "Clock cannot be null");
+        this.retention = Objects.requireNonNull(retention, "Retention cannot be null");
+        if (maxEntriesPerJob <= 0) {
+            throw new IllegalArgumentException("Max entries per job must be positive");
+        }
+        this.maxEntriesPerJob = maxEntriesPerJob;
+    }
+
+    @Override
+    public void record(String identity, DecisionTimelineEntry entry) {
+        timelinesByIdentity.computeIfAbsent(identity, id -> new Timeline())
+                .record(entry, clock.instant().minus(retention), maxEntriesPerJob);
+    }
+
+    @Override
+    public List<DecisionTimelineEntry> entriesFor(String identity) {
+        Timeline timeline = timelinesByIdentity.get(identity);
+        return timeline == null ? List.of() : timeline.snapshot();
+    }
+
+    /**
+     * One job's decision entries, oldest first. Synchronized rather than a lock-free structure: recording happens at
+     * most once per second per job (driven by the scheduler's own trigger-check tick), so contention is a non-issue
+     * and a plain {@link ArrayDeque} behind a monitor is simpler to reason about than a concurrent alternative.
+     */
+    private static final class Timeline {
+
+        private final Deque<DecisionTimelineEntry> entries = new ArrayDeque<>();
+
+        synchronized void record(DecisionTimelineEntry entry, Instant cutoff, int maxEntries) {
+            entries.addLast(entry);
+            while (!entries.isEmpty() && entries.peekFirst().fireTime().isBefore(cutoff)) {
+                entries.removeFirst();
+            }
+            while (entries.size() > maxEntries) {
+                entries.removeFirst();
+            }
+        }
+
+        synchronized List<DecisionTimelineEntry> snapshot() {
+            return List.copyOf(entries);
+        }
+    }
+
+}

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/InMemoryDecisionTimelineStore.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/InMemoryDecisionTimelineStore.java
@@ -3,8 +3,9 @@ package io.carbonintensity.scheduler.runtime;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayDeque;
-import java.util.Deque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -50,21 +51,32 @@ public final class InMemoryDecisionTimelineStore implements DecisionTimelineStor
     }
 
     /**
-     * One job's decision entries, oldest first. Synchronized rather than a lock-free structure: recording happens at
-     * most once per second per job (driven by the scheduler's own trigger-check tick), so contention is a non-issue
-     * and a plain {@link ArrayDeque} behind a monitor is simpler to reason about than a concurrent alternative.
+     * One job's decision entries, kept sorted by {@code fireTime}. Synchronized rather than a lock-free structure:
+     * recording happens at most once per second per job (driven by the scheduler's own trigger-check tick), so
+     * contention is a non-issue and a plain {@link ArrayList} behind a monitor is simpler to reason about than a
+     * concurrent alternative.
+     * <p>
+     * {@link DecisionTimelineStore#record} carries no ordering precondition on the caller, so entries are inserted
+     * at their sorted position rather than always appended - age-based eviction only ever inspects the front of the
+     * list, and that is only correct if the front is always the true oldest entry, regardless of arrival order.
+     * {@link SimpleScheduler} itself only ever calls {@code record} in fireTime order, so this is belt-and-braces
+     * for a default implementation sitting behind a pluggable SPI, not a fix for an observed problem.
      */
     private static final class Timeline {
 
-        private final Deque<DecisionTimelineEntry> entries = new ArrayDeque<>();
+        private static final Comparator<DecisionTimelineEntry> BY_FIRE_TIME = Comparator
+                .comparing(DecisionTimelineEntry::fireTime);
+
+        private final List<DecisionTimelineEntry> entries = new ArrayList<>();
 
         synchronized void record(DecisionTimelineEntry entry, Instant cutoff, int maxEntries) {
-            entries.addLast(entry);
-            while (!entries.isEmpty() && entries.peekFirst().fireTime().isBefore(cutoff)) {
-                entries.removeFirst();
+            int insertionPoint = Collections.binarySearch(entries, entry, BY_FIRE_TIME);
+            entries.add(insertionPoint >= 0 ? insertionPoint : -insertionPoint - 1, entry);
+            while (!entries.isEmpty() && entries.get(0).fireTime().isBefore(cutoff)) {
+                entries.remove(0);
             }
             while (entries.size() > maxEntries) {
-                entries.removeFirst();
+                entries.remove(0);
             }
         }
 

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/MdcEnrichingInvoker.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/MdcEnrichingInvoker.java
@@ -1,0 +1,64 @@
+package io.carbonintensity.scheduler.runtime;
+
+import java.util.concurrent.CompletionStage;
+
+import org.slf4j.MDC;
+
+import io.carbonintensity.scheduler.ScheduledExecution;
+import io.carbonintensity.scheduler.Trigger;
+
+/**
+ * The outermost wrapper of every invoker chain (see {@link SimpleScheduler#initInvoker}) - every log line emitted
+ * anywhere in the chain during a job's invocation, not just inside the innermost invoker, carries the job's
+ * {@code identity}, {@code strategy} and {@code zone} (the same three canonical field names settled on for the
+ * not-yet-implemented CIIO-282 metrics work, for terminology consistency), without every log statement needing to
+ * pass them explicitly.
+ * <p>
+ * MDC is thread-local, so it is cleared eagerly on the calling (dispatch) thread as soon as this invoker's own call
+ * returns, even if the returned {@link CompletionStage} is still pending - that thread comes from a shared,
+ * fixed-size job executor pool and may be handed the next job's dispatch immediately, so it must never carry a
+ * stale value into an unrelated job. If the delegate's completion happens later, on a different thread, MDC is
+ * re-established there just long enough to run the completion callback, then removed again on that thread too.
+ * A job's own asynchronous continuations that log after this method has already returned, on a thread of their
+ * own choosing, are outside what this can guarantee - propagating MDC context across arbitrary executor
+ * boundaries is a larger change than fits here.
+ */
+final class MdcEnrichingInvoker extends DelegateInvoker {
+
+    private static final String MDC_IDENTITY_KEY = "identity";
+    private static final String MDC_STRATEGY_KEY = "strategy";
+    private static final String MDC_ZONE_KEY = "zone";
+
+    MdcEnrichingInvoker(ScheduledInvoker delegate) {
+        super(delegate);
+    }
+
+    @Override
+    public CompletionStage<Void> invoke(ScheduledExecution execution) {
+        Trigger trigger = execution.getTrigger();
+        putMdc(trigger);
+        try {
+            return invokeDelegate(execution).whenComplete((v, t) -> {
+                putMdc(trigger);
+                removeMdc();
+            });
+        } finally {
+            removeMdc();
+        }
+    }
+
+    static void putMdc(Trigger trigger) {
+        MDC.put(MDC_IDENTITY_KEY, trigger.getId());
+        trigger.getDecisionStrategy().ifPresent(strategy -> MDC.put(MDC_STRATEGY_KEY, strategy.name()));
+        String zone = trigger.getCarbonIntensityZone();
+        if (zone != null) {
+            MDC.put(MDC_ZONE_KEY, zone);
+        }
+    }
+
+    private static void removeMdc() {
+        MDC.remove(MDC_IDENTITY_KEY);
+        MDC.remove(MDC_STRATEGY_KEY);
+        MDC.remove(MDC_ZONE_KEY);
+    }
+}

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/MdcEnrichingInvoker.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/MdcEnrichingInvoker.java
@@ -6,6 +6,7 @@ import org.slf4j.MDC;
 
 import io.carbonintensity.scheduler.ScheduledExecution;
 import io.carbonintensity.scheduler.Trigger;
+import io.carbonintensity.scheduler.observability.DecisionStrategy;
 
 /**
  * The outermost wrapper of every invoker chain (see {@link SimpleScheduler#initInvoker}) - every log line emitted
@@ -17,11 +18,9 @@ import io.carbonintensity.scheduler.Trigger;
  * MDC is thread-local, so it is cleared eagerly on the calling (dispatch) thread as soon as this invoker's own call
  * returns, even if the returned {@link CompletionStage} is still pending - that thread comes from a shared,
  * fixed-size job executor pool and may be handed the next job's dispatch immediately, so it must never carry a
- * stale value into an unrelated job. If the delegate's completion happens later, on a different thread, MDC is
- * re-established there just long enough to run the completion callback, then removed again on that thread too.
- * A job's own asynchronous continuations that log after this method has already returned, on a thread of their
- * own choosing, are outside what this can guarantee - propagating MDC context across arbitrary executor
- * boundaries is a larger change than fits here.
+ * stale value into an unrelated job. A job's own asynchronous continuations that log after this method has already
+ * returned, on a thread of their own choosing, are outside what this can guarantee - propagating MDC context
+ * across arbitrary executor boundaries is a larger change than fits here.
  */
 final class MdcEnrichingInvoker extends DelegateInvoker {
 
@@ -38,10 +37,7 @@ final class MdcEnrichingInvoker extends DelegateInvoker {
         Trigger trigger = execution.getTrigger();
         putMdc(trigger);
         try {
-            return invokeDelegate(execution).whenComplete((v, t) -> {
-                putMdc(trigger);
-                removeMdc();
-            });
+            return invokeDelegate(execution);
         } finally {
             removeMdc();
         }
@@ -49,7 +45,10 @@ final class MdcEnrichingInvoker extends DelegateInvoker {
 
     static void putMdc(Trigger trigger) {
         MDC.put(MDC_IDENTITY_KEY, trigger.getId());
-        trigger.getDecisionStrategy().ifPresent(strategy -> MDC.put(MDC_STRATEGY_KEY, strategy.name()));
+        DecisionStrategy strategy = trigger.getDecisionStrategy();
+        if (strategy != null) {
+            MDC.put(MDC_STRATEGY_KEY, strategy.name());
+        }
         String zone = trigger.getCarbonIntensityZone();
         if (zone != null) {
             MDC.put(MDC_ZONE_KEY, zone);

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/MdcEnrichingInvoker.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/MdcEnrichingInvoker.java
@@ -9,18 +9,12 @@ import io.carbonintensity.scheduler.Trigger;
 import io.carbonintensity.scheduler.observability.DecisionStrategy;
 
 /**
- * The outermost wrapper of every invoker chain (see {@link SimpleScheduler#initInvoker}) - every log line emitted
- * anywhere in the chain during a job's invocation, not just inside the innermost invoker, carries the job's
- * {@code identity}, {@code strategy} and {@code zone} (the same three canonical field names settled on for the
- * not-yet-implemented CIIO-282 metrics work, for terminology consistency), without every log statement needing to
- * pass them explicitly.
- * <p>
- * MDC is thread-local, so it is cleared eagerly on the calling (dispatch) thread as soon as this invoker's own call
- * returns, even if the returned {@link CompletionStage} is still pending - that thread comes from a shared,
- * fixed-size job executor pool and may be handed the next job's dispatch immediately, so it must never carry a
- * stale value into an unrelated job. A job's own asynchronous continuations that log after this method has already
- * returned, on a thread of their own choosing, are outside what this can guarantee - propagating MDC context
- * across arbitrary executor boundaries is a larger change than fits here.
+ * The outermost wrapper of every invoker chain (see
+ * {@link SimpleScheduler#initInvoker}) - every log line in the chain during
+ * a job's invocation carries the job's {@code identity}, {@code strategy}
+ * and {@code zone} (the same three canonical names settled on for the
+ * not-yet-implemented CIIO-282 metrics work), without every log statement
+ * needing to pass them explicitly.
  */
 final class MdcEnrichingInvoker extends DelegateInvoker {
 
@@ -32,6 +26,14 @@ final class MdcEnrichingInvoker extends DelegateInvoker {
         super(delegate);
     }
 
+    /**
+     * MDC is thread-local, so it's cleared eagerly on the calling (dispatch)
+     * thread as soon as this call returns, even if the returned
+     * {@link CompletionStage} is still pending - that thread comes from a
+     * shared, fixed-size job executor pool and may be handed the next job's
+     * dispatch immediately, so it must never carry a stale value into an
+     * unrelated job.
+     */
     @Override
     public CompletionStage<Void> invoke(ScheduledExecution execution) {
         Trigger trigger = execution.getTrigger();
@@ -43,6 +45,12 @@ final class MdcEnrichingInvoker extends DelegateInvoker {
         }
     }
 
+    /**
+     * A job's own async continuations that log after this method returns,
+     * on a thread of their own choosing, are outside what this can
+     * guarantee - propagating MDC across arbitrary executor boundaries is
+     * a larger change than fits here.
+     */
     static void putMdc(Trigger trigger) {
         MDC.put(MDC_IDENTITY_KEY, trigger.getId());
         DecisionStrategy strategy = trigger.getDecisionStrategy();

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/SchedulerConfig.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/SchedulerConfig.java
@@ -8,6 +8,7 @@ import io.carbonintensity.executionplanner.runtime.impl.rest.CarbonIntensityApiC
 import io.carbonintensity.executionplanner.spi.CarbonIntensityApi;
 import io.carbonintensity.scheduler.GreenScheduled;
 import io.carbonintensity.scheduler.Scheduler;
+import io.carbonintensity.scheduler.observability.DecisionTimelineStore;
 import io.carbonintensity.scheduler.spi.JobInstrumenter;
 
 /**
@@ -67,6 +68,24 @@ public class SchedulerConfig {
      * the next-best slot instead, but a job's configured window always takes priority over this limit.
      */
     private int maxConcurrentPerSlot = SchedulerDefaults.DEFAULT_MAX_CONCURRENT_PER_SLOT;
+
+    /**
+     * Override hook for the decision-timeline's storage - {@code null} (the default) means the scheduler uses its
+     * own in-memory implementation. See {@link DecisionTimelineStore} for why a consumer might plug in their own.
+     */
+    private DecisionTimelineStore decisionTimelineStore;
+
+    /**
+     * How many days of decision-timeline entries the default in-memory store retains per job. Ignored when
+     * {@link #decisionTimelineStore} is overridden - a custom store is responsible for its own retention policy.
+     */
+    private int decisionTimelineRetentionDays = SchedulerDefaults.DEFAULT_DECISION_TIMELINE_RETENTION_DAYS;
+
+    /**
+     * Hard cap on decision-timeline entries retained per job in the default in-memory store, regardless of age.
+     * Ignored when {@link #decisionTimelineStore} is overridden.
+     */
+    private int decisionTimelineMaxEntriesPerJob = SchedulerDefaults.DEFAULT_DECISION_TIMELINE_MAX_ENTRIES_PER_JOB;
 
     public boolean isEnabled() {
         return enabled;
@@ -175,6 +194,36 @@ public class SchedulerConfig {
 
     public void setClock(Clock clock) {
         this.clock = clock;
+    }
+
+    public DecisionTimelineStore getDecisionTimelineStore() {
+        return decisionTimelineStore;
+    }
+
+    public void setDecisionTimelineStore(DecisionTimelineStore decisionTimelineStore) {
+        this.decisionTimelineStore = decisionTimelineStore;
+    }
+
+    public int getDecisionTimelineRetentionDays() {
+        return decisionTimelineRetentionDays;
+    }
+
+    public void setDecisionTimelineRetentionDays(int decisionTimelineRetentionDays) {
+        if (decisionTimelineRetentionDays < 1) {
+            throw new IllegalArgumentException("Decision-timeline retention days cannot be less than 1");
+        }
+        this.decisionTimelineRetentionDays = decisionTimelineRetentionDays;
+    }
+
+    public int getDecisionTimelineMaxEntriesPerJob() {
+        return decisionTimelineMaxEntriesPerJob;
+    }
+
+    public void setDecisionTimelineMaxEntriesPerJob(int decisionTimelineMaxEntriesPerJob) {
+        if (decisionTimelineMaxEntriesPerJob < 1) {
+            throw new IllegalArgumentException("Decision-timeline max entries per job cannot be less than 1");
+        }
+        this.decisionTimelineMaxEntriesPerJob = decisionTimelineMaxEntriesPerJob;
     }
 
 }

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/SchedulerConfig.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/SchedulerConfig.java
@@ -70,20 +70,24 @@ public class SchedulerConfig {
     private int maxConcurrentPerSlot = SchedulerDefaults.DEFAULT_MAX_CONCURRENT_PER_SLOT;
 
     /**
-     * Override hook for the decision-timeline's storage - {@code null} (the default) means the scheduler uses its
-     * own in-memory implementation. See {@link DecisionTimelineStore} for why a consumer might plug in their own.
+     * Override hook for the decision-timeline's storage - {@code null} (the
+     * default) means the scheduler uses its own in-memory implementation.
+     * See {@link DecisionTimelineStore} for why a consumer might plug in
+     * their own.
      */
     private DecisionTimelineStore decisionTimelineStore;
 
     /**
-     * How many days of decision-timeline entries the default in-memory store retains per job. Ignored when
-     * {@link #decisionTimelineStore} is overridden - a custom store is responsible for its own retention policy.
+     * How many days of decision-timeline entries the default in-memory
+     * store retains per job. Ignored when {@link #decisionTimelineStore}
+     * is overridden - a custom store owns its own retention policy.
      */
     private int decisionTimelineRetentionDays = SchedulerDefaults.DEFAULT_DECISION_TIMELINE_RETENTION_DAYS;
 
     /**
-     * Hard cap on decision-timeline entries retained per job in the default in-memory store, regardless of age.
-     * Ignored when {@link #decisionTimelineStore} is overridden.
+     * Hard cap on decision-timeline entries retained per job in the default
+     * in-memory store, regardless of age. Ignored when
+     * {@link #decisionTimelineStore} is overridden.
      */
     private int decisionTimelineMaxEntriesPerJob = SchedulerDefaults.DEFAULT_DECISION_TIMELINE_MAX_ENTRIES_PER_JOB;
 

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/SchedulerDefaults.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/SchedulerDefaults.java
@@ -21,6 +21,17 @@ public final class SchedulerDefaults {
      */
     public static final int DEFAULT_MAX_CONCURRENT_PER_SLOT = 0;
 
+    /**
+     * How many days of decision-timeline entries the default in-memory store retains per job.
+     */
+    public static final int DEFAULT_DECISION_TIMELINE_RETENTION_DAYS = 30;
+
+    /**
+     * Hard cap on decision-timeline entries retained per job, regardless of age - a safety net against a
+     * pathologically high-frequency job accumulating unbounded memory within the retention window.
+     */
+    public static final int DEFAULT_DECISION_TIMELINE_MAX_ENTRIES_PER_JOB = 1000;
+
     private SchedulerDefaults() {
     }
 }

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/SchedulerDefaults.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/SchedulerDefaults.java
@@ -17,18 +17,21 @@ public final class SchedulerDefaults {
     public static final String DEFAULT_API_URL = "https://api.carbonintensity.io";
     public static final int DEFAULT_NUMBER_OF_JOB_EXECUTORS = 10;
     /**
-     * Disabled by default: jobs schedule independently and may land on the exact same slot.
+     * Disabled by default: jobs schedule independently and may land on the
+     * exact same slot.
      */
     public static final int DEFAULT_MAX_CONCURRENT_PER_SLOT = 0;
 
     /**
-     * How many days of decision-timeline entries the default in-memory store retains per job.
+     * How many days of decision-timeline entries the default in-memory
+     * store retains per job.
      */
     public static final int DEFAULT_DECISION_TIMELINE_RETENTION_DAYS = 30;
 
     /**
-     * Hard cap on decision-timeline entries retained per job, regardless of age - a safety net against a
-     * pathologically high-frequency job accumulating unbounded memory within the retention window.
+     * Hard cap on decision-timeline entries retained per job, regardless of
+     * age - a safety net against a pathologically high-frequency job
+     * accumulating unbounded memory within the retention window.
      */
     public static final int DEFAULT_DECISION_TIMELINE_MAX_ENTRIES_PER_JOB = 1000;
 

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/SimpleScheduler.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/SimpleScheduler.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalDouble;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -50,6 +51,10 @@ import io.carbonintensity.scheduler.ScheduledExecution;
 import io.carbonintensity.scheduler.Scheduler;
 import io.carbonintensity.scheduler.SkipPredicate;
 import io.carbonintensity.scheduler.Trigger;
+import io.carbonintensity.scheduler.observability.DecisionReason;
+import io.carbonintensity.scheduler.observability.DecisionStrategy;
+import io.carbonintensity.scheduler.observability.DecisionTimelineEntry;
+import io.carbonintensity.scheduler.observability.DecisionTimelineStore;
 import io.carbonintensity.scheduler.runtime.SchedulerConfig.StartMode;
 import io.carbonintensity.scheduler.runtime.impl.annotation.GreenScheduledAnnotationParser;
 import io.carbonintensity.scheduler.runtime.impl.rest.CarbonIntensityFileApi;
@@ -119,6 +124,7 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
     private final JobInstrumenter jobInstrumenter;
     private final List<EventListener> eventListeners;
     private final Events events;
+    private final DecisionTimelineStore decisionTimelineStore;
 
     public SimpleScheduler(SchedulerConfig schedulerConfig) {
         this.clock = schedulerConfig.getClock();
@@ -130,6 +136,9 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         this.jobInstrumenter = schedulerConfig.getJobInstrumenter();
         this.eventListeners = new ArrayList<>();
         this.slotTracker = new ConcurrencySlotTracker();
+        this.decisionTimelineStore = Objects.requireNonNullElse(schedulerConfig.getDecisionTimelineStore(),
+                new InMemoryDecisionTimelineStore(clock, Duration.ofDays(schedulerConfig.getDecisionTimelineRetentionDays()),
+                        schedulerConfig.getDecisionTimelineMaxEntriesPerJob()));
 
         if (!schedulerConfig.isEnabled()) {
             log.info("Simple scheduler is disabled by config property and will not be started.");
@@ -332,11 +341,48 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         log.trace("Check triggers at {}", now);
         for (ScheduledTask task : scheduledTasks.values()) {
             try {
-                task.execute(now, jobExecutor);
+                ZonedDateTime scheduledFireTime = task.execute(now, jobExecutor);
+                if (scheduledFireTime != null) {
+                    recordDecision(task.trigger, scheduledFireTime);
+                }
             } catch (Exception e) {
                 log.warn("Unexpected exception while executing trigger for {}", task.trigger.getMethodDescription(), e);
             }
         }
+    }
+
+    /**
+     * Records a {@link DecisionTimelineEntry} for a real trigger fire, unconditionally - no {@code @GreenObserved}
+     * opt-in required, since this is the "is this a black box" baseline the decision timeline exists for.
+     * <p>
+     * {@link SimpleTrigger#strategy()} throws by default, only overridden by {@link FixedWindowTrigger} and
+     * {@link SuccessiveTrigger} - any other trigger type (an internal, non-adopter-facing trigger with no "green"
+     * decision to explain) is silently excluded from the decision timeline by simply never overriding it.
+     */
+    private void recordDecision(SimpleTrigger trigger, ZonedDateTime scheduledFireTime) {
+        DecisionStrategy strategy;
+        try {
+            strategy = trigger.strategy();
+        } catch (UnsupportedOperationException e) {
+            return;
+        }
+        DecisionReason reason = trigger.lastDecisionReason;
+        if (reason == null) {
+            log.warn("Job '{}' fired without a recorded decision reason - skipping its decision-timeline entry",
+                    trigger.getId());
+            return;
+        }
+        DecisionTimelineEntry entry = new DecisionTimelineEntry(scheduledFireTime.toInstant(), strategy, reason,
+                OptionalDouble.empty());
+        try {
+            decisionTimelineStore.record(trigger.getId(), entry);
+        } catch (RuntimeException e) {
+            // observability must never break business logic - the job itself already ran (or is running)
+            // regardless of this failure
+            log.warn("Failed to record a decision-timeline entry for job '{}' - continuing without it", trigger.getId(), e);
+            return;
+        }
+        events.fireJobDecisionRecorded(trigger, entry);
     }
 
     @Override
@@ -490,9 +536,9 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
             this.isProgrammatic = isProgrammatic;
         }
 
-        void execute(ZonedDateTime now, ExecutorService executorService) {
+        ZonedDateTime execute(ZonedDateTime now, ExecutorService executorService) {
             if (trigger.isPaused()) {
-                return;
+                return null;
             }
 
             // evaluate if we need to fire
@@ -500,6 +546,7 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
             if (scheduledFireTime != null) {
                 executorService.execute(() -> doInvoke(now, scheduledFireTime));
             }
+            return scheduledFireTime;
         }
 
         void doInvoke(ZonedDateTime now, ZonedDateTime scheduledFireTime) {
@@ -579,8 +626,10 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
                 if (nextExecutionTime != null) {
                     ZonedDateTime nextTruncated = nextExecutionTime.truncatedTo(ChronoUnit.SECONDS);
                     if (now.isAfter(nextTruncated) && (lastFireTime == null || lastFireTime.isBefore(nextTruncated))) {
-                        log.trace("{} fired, trigger={}", this, nextTruncated);
+                        log.debug("Job '{}' fired at {} (greenest available slot honoring its gap window)", getId(),
+                                nextTruncated);
                         lastFireTime = now;
+                        lastDecisionReason = DecisionReason.GREENEST_AVAILABLE_SLOT;
                         return nextTruncated;
                     }
                 }
@@ -602,6 +651,11 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
             }
             // fallback to interval trigger
             return super.isOverdue();
+        }
+
+        @Override
+        DecisionStrategy strategy() {
+            return DecisionStrategy.SUCCESSIVE;
         }
     }
 
@@ -630,6 +684,7 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         private volatile boolean running;
         protected final ZonedDateTime start;
         protected volatile ZonedDateTime lastFireTime;
+        volatile DecisionReason lastDecisionReason;
 
         SimpleTrigger(String id, Clock clock, ZonedDateTime start, String description) {
             this.id = id;
@@ -666,6 +721,20 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         @Override
         public String getMethodDescription() {
             return methodDescription;
+        }
+
+        /**
+         * Which top-level {@link DecisionStrategy} this trigger represents, for the decision timeline.
+         * <p>
+         * Throws by default: only {@link FixedWindowTrigger} and {@link SuccessiveTrigger} - the only trigger types
+         * ever registered as a job's own top-level trigger - override this. {@link CronTrigger}/{@link IntervalTrigger}
+         * are only ever reached internally as their fallback path and never registered directly, so they never need
+         * to answer this; a future internal-only trigger type that doesn't override this is, by design, silently
+         * excluded from the decision timeline (see {@code recordDecision}) rather than needing an explicit opt-out.
+         */
+        DecisionStrategy strategy() {
+            throw new UnsupportedOperationException(
+                    "No decision-timeline strategy defined for " + getClass().getSimpleName());
         }
     }
 
@@ -706,8 +775,9 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
                 if (lastExecution.isPresent()) {
                     ZonedDateTime lastTruncated = lastExecution.get().truncatedTo(ChronoUnit.SECONDS);
                     if (now.isAfter(lastTruncated) && (lastFireTime == null || lastFireTime.isBefore(lastTruncated))) {
-                        log.trace("{} fired, last={}", this, lastTruncated);
+                        log.debug("Job '{}' fired at {} (fallback to its configured cron schedule)", this.id, lastTruncated);
                         this.lastFireTime = now;
+                        this.lastDecisionReason = DecisionReason.FALLBACK_TO_CONFIGURED_CRON;
                         return lastTruncated;
                     }
                 }
@@ -794,8 +864,9 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
                 if (nextExecutionTime != null) {
                     ZonedDateTime nextTruncated = nextExecutionTime.truncatedTo(ChronoUnit.SECONDS);
                     if (now.isAfter(nextTruncated) && (lastFireTime == null || lastFireTime.isBefore(nextTruncated))) {
-                        log.trace("{} fired, trigger={}, updating constraints for next run", this, nextTruncated);
+                        log.debug("Job '{}' fired at {} (greenest available slot in its window)", this.id, nextTruncated);
                         lastFireTime = now;
+                        lastDecisionReason = DecisionReason.GREENEST_AVAILABLE_SLOT;
                         constraints = DefaultFixedWindowPlanningConstraints.from(constraints)
                                 .withStartAndEnd(constraints.getStart().plusDays(1), constraints.getEnd().plusDays(1))
                                 .build();
@@ -810,6 +881,11 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         @Override
         public boolean isOverdue() {
             return false;
+        }
+
+        @Override
+        DecisionStrategy strategy() {
+            return DecisionStrategy.FIXED_WINDOW;
         }
     }
 
@@ -850,13 +926,15 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
             if (lastFireTime == null) {
                 // First execution
                 lastFireTime = now.truncatedTo(ChronoUnit.SECONDS);
+                lastDecisionReason = DecisionReason.FALLBACK_TO_PLAIN_INTERVAL;
                 return now;
             }
             long diff = ChronoUnit.MILLIS.between(lastFireTime, now);
             if (diff >= interval) {
                 ZonedDateTime scheduledFireTime = lastFireTime.plus(Duration.ofMillis(interval));
                 lastFireTime = now.truncatedTo(ChronoUnit.SECONDS);
-                log.trace("{} fired, diff={} ms", this, diff);
+                log.debug("Job '{}' fired at {} (fallback to plain interval spacing)", getId(), scheduledFireTime);
+                lastDecisionReason = DecisionReason.FALLBACK_TO_PLAIN_INTERVAL;
                 return scheduledFireTime;
             }
             return null;

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/SimpleScheduler.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/SimpleScheduler.java
@@ -353,12 +353,12 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
     }
 
     /**
-     * Records a {@link DecisionTimelineEntry} for a real trigger fire, unconditionally - no {@code @GreenObserved}
-     * opt-in required, since this is the "is this a black box" baseline the decision timeline exists for.
-     * <p>
-     * {@link Trigger#getDecisionStrategy()} defaults to {@code null}, only overridden by {@link FixedWindowTrigger}
-     * and {@link SuccessiveTrigger} - any other trigger type (an internal, non-adopter-facing trigger with no
-     * "green" decision to explain) is silently excluded from the decision timeline by simply never overriding it.
+     * Records a {@link DecisionTimelineEntry} for a real trigger fire,
+     * unconditionally - no opt-in needed, since this is the "is this a
+     * black box" baseline the decision timeline exists for.
+     * {@link Trigger#getDecisionStrategy()} defaults to {@code null}; only
+     * {@link FixedWindowTrigger}/{@link SuccessiveTrigger} override it, so
+     * other trigger types are silently excluded from the timeline.
      */
     private void recordDecision(SimpleTrigger trigger, EvaluationResult result) {
         DecisionStrategy strategy = trigger.getDecisionStrategy();
@@ -371,8 +371,8 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         try {
             decisionTimelineStore.record(trigger.getId(), entry);
         } catch (RuntimeException e) {
-            // observability must never break business logic - the job itself already ran (or is running)
-            // regardless of this failure
+            // observability must never break business logic - the job itself
+            // already ran (or is running) regardless of this failure
             log.warn("Failed to record a decision-timeline entry for job '{}' - continuing without it", trigger.getId(), e);
             return;
         }
@@ -500,8 +500,9 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         if (instrumenter != null) {
             invoker = new InstrumentedInvoker(invoker, instrumenter);
         }
-        // Outermost: every decorator above logs before delegating down, so MDC must be established before any
-        // of them run, not just inside the innermost one.
+        // Outermost: every decorator above logs before delegating down, so
+        // MDC must be established before any of them run, not just inside
+        // the innermost one.
         return new MdcEnrichingInvoker(invoker);
     }
 
@@ -521,9 +522,10 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
     }
 
     /**
-     * A trigger's decision, bundled with the fire time it applies to - the two are always produced together by
-     * {@link SimpleTrigger#evaluate}, so they travel together rather than the outcome being smuggled out via a
-     * mutable field on the trigger for {@link #recordDecision} to re-read moments later.
+     * A trigger's decision, bundled with the fire time it applies to - the
+     * two are always produced together by {@link SimpleTrigger#evaluate},
+     * so they travel together rather than being smuggled out via a mutable
+     * field for {@link #recordDecision} to re-read moments later.
      */
     record EvaluationResult(ZonedDateTime fireTime, DecisionOutcome outcome) {
     }

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/SimpleScheduler.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/SimpleScheduler.java
@@ -1,5 +1,6 @@
 package io.carbonintensity.scheduler.runtime;
 
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -44,6 +45,7 @@ import io.carbonintensity.executionplanner.runtime.impl.rest.CarbonIntensityApiT
 import io.carbonintensity.executionplanner.runtime.impl.rest.CarbonIntensityRestApi;
 import io.carbonintensity.executionplanner.spi.CarbonIntensityPlanner;
 import io.carbonintensity.executionplanner.spi.ConcurrencySlotTracker;
+import io.carbonintensity.executionplanner.spi.PlannedExecution;
 import io.carbonintensity.executionplanner.spi.PlanningConstraints;
 import io.carbonintensity.scheduler.ConcurrentExecution;
 import io.carbonintensity.scheduler.GreenScheduled;
@@ -355,15 +357,14 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
      * Records a {@link DecisionTimelineEntry} for a real trigger fire, unconditionally - no {@code @GreenObserved}
      * opt-in required, since this is the "is this a black box" baseline the decision timeline exists for.
      * <p>
-     * {@link SimpleTrigger#strategy()} throws by default, only overridden by {@link FixedWindowTrigger} and
-     * {@link SuccessiveTrigger} - any other trigger type (an internal, non-adopter-facing trigger with no "green"
-     * decision to explain) is silently excluded from the decision timeline by simply never overriding it.
+     * {@link Trigger#getDecisionStrategy()} defaults to {@link Optional#empty()}, only overridden by
+     * {@link FixedWindowTrigger} and {@link SuccessiveTrigger} - any other trigger type (an internal,
+     * non-adopter-facing trigger with no "green" decision to explain) is silently excluded from the decision
+     * timeline by simply never overriding it.
      */
     private void recordDecision(SimpleTrigger trigger, ZonedDateTime scheduledFireTime) {
-        DecisionStrategy strategy;
-        try {
-            strategy = trigger.strategy();
-        } catch (UnsupportedOperationException e) {
+        Optional<DecisionStrategy> strategy = trigger.getDecisionStrategy();
+        if (strategy.isEmpty()) {
             return;
         }
         DecisionReason reason = trigger.lastDecisionReason;
@@ -372,8 +373,12 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
                     trigger.getId());
             return;
         }
-        DecisionTimelineEntry entry = new DecisionTimelineEntry(scheduledFireTime.toInstant(), strategy, reason,
-                OptionalDouble.empty());
+        // absent for fallback-driven fires (cron/plain-interval) that never went through a carbon-aware planner
+        // call at all - never fabricated
+        OptionalDouble intensityValue = trigger.lastDecisionIntensityValue.stream().mapToDouble(BigDecimal::doubleValue)
+                .findFirst();
+        DecisionTimelineEntry entry = new DecisionTimelineEntry(scheduledFireTime.toInstant(), strategy.get(), reason,
+                intensityValue);
         try {
             decisionTimelineStore.record(trigger.getId(), entry);
         } catch (RuntimeException e) {
@@ -595,7 +600,7 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         @Override
         public Instant getNextFireTime() {
             if (successivePlanner.canSchedule(constraints)) {
-                return successivePlanner.getNextExecutionTime(constraints).toInstant();
+                return successivePlanner.getNextExecutionTime(constraints).fireTime().toInstant();
             }
             // fallback to interval trigger
             return super.getNextFireTime();
@@ -608,28 +613,29 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
                     return null;
                 }
 
-                ZonedDateTime nextExecutionTime = null;
+                PlannedExecution nextExecution = null;
 
                 // first invocation
                 if (lastFireTime == null) {
-                    nextExecutionTime = successivePlanner.getNextExecutionTime(constraints);
+                    nextExecution = successivePlanner.getNextExecutionTime(constraints);
                 }
 
                 // sequential invocations
                 if (lastFireTime != null && now.plusSeconds(1).isAfter(lastFireTime.plus(constraints.getMinimumGap()))) {
-                    nextExecutionTime = successivePlanner
+                    nextExecution = successivePlanner
                             .getNextExecutionTime(DefaultSuccessivePlanningConstraints.from(constraints)
                                     .withLastExecutionTime(lastFireTime)
                                     .build());
                 }
 
-                if (nextExecutionTime != null) {
-                    ZonedDateTime nextTruncated = nextExecutionTime.truncatedTo(ChronoUnit.SECONDS);
+                if (nextExecution != null) {
+                    ZonedDateTime nextTruncated = nextExecution.fireTime().truncatedTo(ChronoUnit.SECONDS);
                     if (now.isAfter(nextTruncated) && (lastFireTime == null || lastFireTime.isBefore(nextTruncated))) {
                         log.debug("Job '{}' fired at {} (greenest available slot honoring its gap window)", getId(),
                                 nextTruncated);
                         lastFireTime = now;
                         lastDecisionReason = DecisionReason.GREENEST_AVAILABLE_SLOT;
+                        lastDecisionIntensityValue = nextExecution.intensityValue();
                         return nextTruncated;
                     }
                 }
@@ -654,8 +660,13 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         }
 
         @Override
-        DecisionStrategy strategy() {
-            return DecisionStrategy.SUCCESSIVE;
+        public Optional<DecisionStrategy> getDecisionStrategy() {
+            return Optional.of(DecisionStrategy.SUCCESSIVE);
+        }
+
+        @Override
+        public String getCarbonIntensityZone() {
+            return constraints.getCarbonIntensityZone();
         }
     }
 
@@ -685,6 +696,7 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         protected final ZonedDateTime start;
         protected volatile ZonedDateTime lastFireTime;
         volatile DecisionReason lastDecisionReason;
+        volatile Optional<BigDecimal> lastDecisionIntensityValue = Optional.empty();
 
         SimpleTrigger(String id, Clock clock, ZonedDateTime start, String description) {
             this.id = id;
@@ -721,20 +733,6 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         @Override
         public String getMethodDescription() {
             return methodDescription;
-        }
-
-        /**
-         * Which top-level {@link DecisionStrategy} this trigger represents, for the decision timeline.
-         * <p>
-         * Throws by default: only {@link FixedWindowTrigger} and {@link SuccessiveTrigger} - the only trigger types
-         * ever registered as a job's own top-level trigger - override this. {@link CronTrigger}/{@link IntervalTrigger}
-         * are only ever reached internally as their fallback path and never registered directly, so they never need
-         * to answer this; a future internal-only trigger type that doesn't override this is, by design, silently
-         * excluded from the decision timeline (see {@code recordDecision}) rather than needing an explicit opt-out.
-         */
-        DecisionStrategy strategy() {
-            throw new UnsupportedOperationException(
-                    "No decision-timeline strategy defined for " + getClass().getSimpleName());
         }
     }
 
@@ -843,7 +841,7 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
 
         @Override
         public Instant getNextFireTime() {
-            return planner.getNextExecutionTime(constraints).toInstant();
+            return planner.getNextExecutionTime(constraints).fireTime().toInstant();
         }
 
         @Override
@@ -860,17 +858,18 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
 
             // first invocation
             if (lastFireTime == null || now.isAfter(lastFireTime)) {
-                ZonedDateTime nextExecutionTime = planner.getNextExecutionTime(constraints);
-                if (nextExecutionTime != null) {
-                    ZonedDateTime nextTruncated = nextExecutionTime.truncatedTo(ChronoUnit.SECONDS);
+                PlannedExecution nextExecution = planner.getNextExecutionTime(constraints);
+                if (nextExecution != null) {
+                    ZonedDateTime nextTruncated = nextExecution.fireTime().truncatedTo(ChronoUnit.SECONDS);
                     if (now.isAfter(nextTruncated) && (lastFireTime == null || lastFireTime.isBefore(nextTruncated))) {
                         log.debug("Job '{}' fired at {} (greenest available slot in its window)", this.id, nextTruncated);
                         lastFireTime = now;
                         lastDecisionReason = DecisionReason.GREENEST_AVAILABLE_SLOT;
+                        lastDecisionIntensityValue = nextExecution.intensityValue();
                         constraints = DefaultFixedWindowPlanningConstraints.from(constraints)
                                 .withStartAndEnd(constraints.getStart().plusDays(1), constraints.getEnd().plusDays(1))
                                 .build();
-                        return nextExecutionTime;
+                        return nextExecution.fireTime();
                     }
                 }
             }
@@ -884,8 +883,13 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         }
 
         @Override
-        DecisionStrategy strategy() {
-            return DecisionStrategy.FIXED_WINDOW;
+        public Optional<DecisionStrategy> getDecisionStrategy() {
+            return Optional.of(DecisionStrategy.FIXED_WINDOW);
+        }
+
+        @Override
+        public String getCarbonIntensityZone() {
+            return constraints.getCarbonIntensityZone();
         }
     }
 

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/SimpleScheduler.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/SimpleScheduler.java
@@ -342,9 +342,9 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         log.trace("Check triggers at {}", now);
         for (ScheduledTask task : scheduledTasks.values()) {
             try {
-                ZonedDateTime scheduledFireTime = task.execute(now, jobExecutor);
-                if (scheduledFireTime != null) {
-                    recordDecision(task.trigger, scheduledFireTime);
+                EvaluationResult result = task.execute(now, jobExecutor);
+                if (result != null) {
+                    recordDecision(task.trigger, result);
                 }
             } catch (Exception e) {
                 log.warn("Unexpected exception while executing trigger for {}", task.trigger.getMethodDescription(), e);
@@ -356,23 +356,17 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
      * Records a {@link DecisionTimelineEntry} for a real trigger fire, unconditionally - no {@code @GreenObserved}
      * opt-in required, since this is the "is this a black box" baseline the decision timeline exists for.
      * <p>
-     * {@link Trigger#getDecisionStrategy()} defaults to {@link Optional#empty()}, only overridden by
-     * {@link FixedWindowTrigger} and {@link SuccessiveTrigger} - any other trigger type (an internal,
-     * non-adopter-facing trigger with no "green" decision to explain) is silently excluded from the decision
-     * timeline by simply never overriding it.
+     * {@link Trigger#getDecisionStrategy()} defaults to {@code null}, only overridden by {@link FixedWindowTrigger}
+     * and {@link SuccessiveTrigger} - any other trigger type (an internal, non-adopter-facing trigger with no
+     * "green" decision to explain) is silently excluded from the decision timeline by simply never overriding it.
      */
-    private void recordDecision(SimpleTrigger trigger, ZonedDateTime scheduledFireTime) {
-        Optional<DecisionStrategy> strategy = trigger.getDecisionStrategy();
-        if (strategy.isEmpty()) {
+    private void recordDecision(SimpleTrigger trigger, EvaluationResult result) {
+        DecisionStrategy strategy = trigger.getDecisionStrategy();
+        if (strategy == null) {
             return;
         }
-        DecisionOutcome outcome = trigger.lastDecisionOutcome;
-        if (outcome == null) {
-            log.warn("Job '{}' fired without a recorded decision outcome - skipping its decision-timeline entry",
-                    trigger.getId());
-            return;
-        }
-        DecisionTimelineEntry entry = new DecisionTimelineEntry(scheduledFireTime.toInstant(), strategy.get(), outcome.reason(),
+        DecisionOutcome outcome = result.outcome();
+        DecisionTimelineEntry entry = new DecisionTimelineEntry(result.fireTime().toInstant(), strategy, outcome.reason(),
                 outcome.intensityValue());
         try {
             decisionTimelineStore.record(trigger.getId(), entry);
@@ -526,6 +520,14 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         }
     }
 
+    /**
+     * A trigger's decision, bundled with the fire time it applies to - the two are always produced together by
+     * {@link SimpleTrigger#evaluate}, so they travel together rather than the outcome being smuggled out via a
+     * mutable field on the trigger for {@link #recordDecision} to re-read moments later.
+     */
+    record EvaluationResult(ZonedDateTime fireTime, DecisionOutcome outcome) {
+    }
+
     static class ScheduledTask {
 
         final boolean isProgrammatic;
@@ -538,17 +540,17 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
             this.isProgrammatic = isProgrammatic;
         }
 
-        ZonedDateTime execute(ZonedDateTime now, ExecutorService executorService) {
+        EvaluationResult execute(ZonedDateTime now, ExecutorService executorService) {
             if (trigger.isPaused()) {
                 return null;
             }
 
             // evaluate if we need to fire
-            ZonedDateTime scheduledFireTime = trigger.evaluate(now);
-            if (scheduledFireTime != null) {
-                executorService.execute(() -> doInvoke(now, scheduledFireTime));
+            EvaluationResult result = trigger.evaluate(now);
+            if (result != null) {
+                executorService.execute(() -> doInvoke(now, result.fireTime()));
             }
-            return scheduledFireTime;
+            return result;
         }
 
         void doInvoke(ZonedDateTime now, ZonedDateTime scheduledFireTime) {
@@ -604,7 +606,7 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         }
 
         @Override
-        ZonedDateTime evaluate(ZonedDateTime now) {
+        EvaluationResult evaluate(ZonedDateTime now) {
             if (successivePlanner.canSchedule(constraints)) {
                 if (now.isBefore(start)) {
                     return null;
@@ -631,8 +633,8 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
                         log.debug("Job '{}' fired at {} (greenest available slot honoring its gap window)", getId(),
                                 nextTruncated);
                         lastFireTime = now;
-                        lastDecisionOutcome = DecisionOutcome.from(nextExecution, DecisionReason.GREENEST_AVAILABLE_SLOT);
-                        return nextTruncated;
+                        DecisionOutcome outcome = DecisionOutcome.from(nextExecution, DecisionReason.GREENEST_AVAILABLE_SLOT);
+                        return new EvaluationResult(nextTruncated, outcome);
                     }
                 }
                 return null;
@@ -656,8 +658,8 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         }
 
         @Override
-        public Optional<DecisionStrategy> getDecisionStrategy() {
-            return Optional.of(DecisionStrategy.SUCCESSIVE);
+        public DecisionStrategy getDecisionStrategy() {
+            return DecisionStrategy.SUCCESSIVE;
         }
 
         @Override
@@ -691,7 +693,6 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         private volatile boolean running;
         protected final ZonedDateTime start;
         protected volatile ZonedDateTime lastFireTime;
-        volatile DecisionOutcome lastDecisionOutcome;
 
         SimpleTrigger(String id, Clock clock, ZonedDateTime start, String description) {
             this.id = id;
@@ -705,7 +706,7 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
          * @param now The current date-time in the default time carbonIntensityZone
          * @return the scheduled time if fired, {@code null} otherwise
          */
-        abstract ZonedDateTime evaluate(ZonedDateTime now);
+        abstract EvaluationResult evaluate(ZonedDateTime now);
 
         @Override
         public Instant getPreviousFireTime() {
@@ -759,7 +760,7 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
                     .orElse(null);
         }
 
-        ZonedDateTime evaluate(ZonedDateTime now) {
+        EvaluationResult evaluate(ZonedDateTime now) {
             if (now.isBefore(this.start)) {
                 return null;
             } else {
@@ -770,9 +771,9 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
                     if (now.isAfter(lastTruncated) && (lastFireTime == null || lastFireTime.isBefore(lastTruncated))) {
                         log.debug("Job '{}' fired at {} (fallback to its configured cron schedule)", this.id, lastTruncated);
                         this.lastFireTime = now;
-                        this.lastDecisionOutcome = new DecisionOutcome(DecisionReason.FALLBACK_TO_CONFIGURED_CRON,
+                        DecisionOutcome outcome = new DecisionOutcome(DecisionReason.FALLBACK_TO_CONFIGURED_CRON,
                                 OptionalDouble.empty());
-                        return lastTruncated;
+                        return new EvaluationResult(lastTruncated, outcome);
                     }
                 }
 
@@ -841,7 +842,7 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         }
 
         @Override
-        ZonedDateTime evaluate(ZonedDateTime now) {
+        EvaluationResult evaluate(ZonedDateTime now) {
             if (!planner.canSchedule(constraints)) {
                 // fallback to cron trigger
                 return super.evaluate(now);
@@ -860,11 +861,11 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
                     if (now.isAfter(nextTruncated) && (lastFireTime == null || lastFireTime.isBefore(nextTruncated))) {
                         log.debug("Job '{}' fired at {} (greenest available slot in its window)", this.id, nextTruncated);
                         lastFireTime = now;
-                        lastDecisionOutcome = DecisionOutcome.from(nextExecution, DecisionReason.GREENEST_AVAILABLE_SLOT);
+                        DecisionOutcome outcome = DecisionOutcome.from(nextExecution, DecisionReason.GREENEST_AVAILABLE_SLOT);
                         constraints = DefaultFixedWindowPlanningConstraints.from(constraints)
                                 .withStartAndEnd(constraints.getStart().plusDays(1), constraints.getEnd().plusDays(1))
                                 .build();
-                        return nextExecution.fireTime();
+                        return new EvaluationResult(nextExecution.fireTime(), outcome);
                     }
                 }
             }
@@ -878,8 +879,8 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         }
 
         @Override
-        public Optional<DecisionStrategy> getDecisionStrategy() {
-            return Optional.of(DecisionStrategy.FIXED_WINDOW);
+        public DecisionStrategy getDecisionStrategy() {
+            return DecisionStrategy.FIXED_WINDOW;
         }
 
         @Override
@@ -918,23 +919,22 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         }
 
         @Override
-        ZonedDateTime evaluate(ZonedDateTime now) {
+        EvaluationResult evaluate(ZonedDateTime now) {
             if (now.isBefore(start)) {
                 return null;
             }
+            DecisionOutcome outcome = new DecisionOutcome(DecisionReason.FALLBACK_TO_PLAIN_INTERVAL, OptionalDouble.empty());
             if (lastFireTime == null) {
                 // First execution
                 lastFireTime = now.truncatedTo(ChronoUnit.SECONDS);
-                lastDecisionOutcome = new DecisionOutcome(DecisionReason.FALLBACK_TO_PLAIN_INTERVAL, OptionalDouble.empty());
-                return now;
+                return new EvaluationResult(now, outcome);
             }
             long diff = ChronoUnit.MILLIS.between(lastFireTime, now);
             if (diff >= interval) {
                 ZonedDateTime scheduledFireTime = lastFireTime.plus(Duration.ofMillis(interval));
                 lastFireTime = now.truncatedTo(ChronoUnit.SECONDS);
                 log.debug("Job '{}' fired at {} (fallback to plain interval spacing)", getId(), scheduledFireTime);
-                lastDecisionOutcome = new DecisionOutcome(DecisionReason.FALLBACK_TO_PLAIN_INTERVAL, OptionalDouble.empty());
-                return scheduledFireTime;
+                return new EvaluationResult(scheduledFireTime, outcome);
             }
             return null;
         }

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/SimpleScheduler.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/SimpleScheduler.java
@@ -1,6 +1,5 @@
 package io.carbonintensity.scheduler.runtime;
 
-import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -367,18 +366,14 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         if (strategy.isEmpty()) {
             return;
         }
-        DecisionReason reason = trigger.lastDecisionReason;
-        if (reason == null) {
-            log.warn("Job '{}' fired without a recorded decision reason - skipping its decision-timeline entry",
+        DecisionOutcome outcome = trigger.lastDecisionOutcome;
+        if (outcome == null) {
+            log.warn("Job '{}' fired without a recorded decision outcome - skipping its decision-timeline entry",
                     trigger.getId());
             return;
         }
-        // absent for fallback-driven fires (cron/plain-interval) that never went through a carbon-aware planner
-        // call at all - never fabricated
-        OptionalDouble intensityValue = trigger.lastDecisionIntensityValue.stream().mapToDouble(BigDecimal::doubleValue)
-                .findFirst();
-        DecisionTimelineEntry entry = new DecisionTimelineEntry(scheduledFireTime.toInstant(), strategy.get(), reason,
-                intensityValue);
+        DecisionTimelineEntry entry = new DecisionTimelineEntry(scheduledFireTime.toInstant(), strategy.get(), outcome.reason(),
+                outcome.intensityValue());
         try {
             decisionTimelineStore.record(trigger.getId(), entry);
         } catch (RuntimeException e) {
@@ -511,7 +506,9 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         if (instrumenter != null) {
             invoker = new InstrumentedInvoker(invoker, instrumenter);
         }
-        return invoker;
+        // Outermost: every decorator above logs before delegating down, so MDC must be established before any
+        // of them run, not just inside the innermost one.
+        return new MdcEnrichingInvoker(invoker);
     }
 
     public static SkipPredicate initSkipPredicate(Class<? extends SkipPredicate> predicateClass) {
@@ -634,8 +631,7 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
                         log.debug("Job '{}' fired at {} (greenest available slot honoring its gap window)", getId(),
                                 nextTruncated);
                         lastFireTime = now;
-                        lastDecisionReason = DecisionReason.GREENEST_AVAILABLE_SLOT;
-                        lastDecisionIntensityValue = nextExecution.intensityValue();
+                        lastDecisionOutcome = DecisionOutcome.from(nextExecution, DecisionReason.GREENEST_AVAILABLE_SLOT);
                         return nextTruncated;
                     }
                 }
@@ -695,8 +691,7 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         private volatile boolean running;
         protected final ZonedDateTime start;
         protected volatile ZonedDateTime lastFireTime;
-        volatile DecisionReason lastDecisionReason;
-        volatile Optional<BigDecimal> lastDecisionIntensityValue = Optional.empty();
+        volatile DecisionOutcome lastDecisionOutcome;
 
         SimpleTrigger(String id, Clock clock, ZonedDateTime start, String description) {
             this.id = id;
@@ -775,7 +770,8 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
                     if (now.isAfter(lastTruncated) && (lastFireTime == null || lastFireTime.isBefore(lastTruncated))) {
                         log.debug("Job '{}' fired at {} (fallback to its configured cron schedule)", this.id, lastTruncated);
                         this.lastFireTime = now;
-                        this.lastDecisionReason = DecisionReason.FALLBACK_TO_CONFIGURED_CRON;
+                        this.lastDecisionOutcome = new DecisionOutcome(DecisionReason.FALLBACK_TO_CONFIGURED_CRON,
+                                OptionalDouble.empty());
                         return lastTruncated;
                     }
                 }
@@ -864,8 +860,7 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
                     if (now.isAfter(nextTruncated) && (lastFireTime == null || lastFireTime.isBefore(nextTruncated))) {
                         log.debug("Job '{}' fired at {} (greenest available slot in its window)", this.id, nextTruncated);
                         lastFireTime = now;
-                        lastDecisionReason = DecisionReason.GREENEST_AVAILABLE_SLOT;
-                        lastDecisionIntensityValue = nextExecution.intensityValue();
+                        lastDecisionOutcome = DecisionOutcome.from(nextExecution, DecisionReason.GREENEST_AVAILABLE_SLOT);
                         constraints = DefaultFixedWindowPlanningConstraints.from(constraints)
                                 .withStartAndEnd(constraints.getStart().plusDays(1), constraints.getEnd().plusDays(1))
                                 .build();
@@ -930,7 +925,7 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
             if (lastFireTime == null) {
                 // First execution
                 lastFireTime = now.truncatedTo(ChronoUnit.SECONDS);
-                lastDecisionReason = DecisionReason.FALLBACK_TO_PLAIN_INTERVAL;
+                lastDecisionOutcome = new DecisionOutcome(DecisionReason.FALLBACK_TO_PLAIN_INTERVAL, OptionalDouble.empty());
                 return now;
             }
             long diff = ChronoUnit.MILLIS.between(lastFireTime, now);
@@ -938,7 +933,7 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
                 ZonedDateTime scheduledFireTime = lastFireTime.plus(Duration.ofMillis(interval));
                 lastFireTime = now.truncatedTo(ChronoUnit.SECONDS);
                 log.debug("Job '{}' fired at {} (fallback to plain interval spacing)", getId(), scheduledFireTime);
-                lastDecisionReason = DecisionReason.FALLBACK_TO_PLAIN_INTERVAL;
+                lastDecisionOutcome = new DecisionOutcome(DecisionReason.FALLBACK_TO_PLAIN_INTERVAL, OptionalDouble.empty());
                 return scheduledFireTime;
             }
             return null;

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/StatusEmitterInvoker.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/StatusEmitterInvoker.java
@@ -7,17 +7,20 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import io.carbonintensity.scheduler.ScheduledExecution;
+import io.carbonintensity.scheduler.Trigger;
 
 /**
  * An invoker wrapper that fires events when an execution of a scheduled method is finished.
  * <p>
  * Also the wrapping point for MDC enrichment: every log line emitted during a job's invocation carries the job's
- * {@code identity} (the canonical field name, matching what the metrics/decision-timeline machinery already uses),
- * without every log statement in the invoker chain needing to pass it explicitly.
+ * {@code identity}, {@code strategy} and {@code zone} (the same three canonical field names CIIO-282's metric tags
+ * already use), without every log statement in the invoker chain needing to pass them explicitly.
  */
 public final class StatusEmitterInvoker extends DelegateInvoker {
 
     private static final String MDC_IDENTITY_KEY = "identity";
+    private static final String MDC_STRATEGY_KEY = "strategy";
+    private static final String MDC_ZONE_KEY = "zone";
 
     private static final Logger log = LoggerFactory.getLogger(StatusEmitterInvoker.class);
     private final Events events;
@@ -29,30 +32,45 @@ public final class StatusEmitterInvoker extends DelegateInvoker {
 
     @Override
     public CompletionStage<Void> invoke(ScheduledExecution execution) {
-        String identity = execution.getTrigger().getId();
-        MDC.put(MDC_IDENTITY_KEY, identity);
+        Trigger trigger = execution.getTrigger();
+        putMdc(trigger);
         try {
-            log.trace("Running status emitter invoker for {} at {}.", identity, execution.getScheduledFireTime());
+            log.trace("Running status emitter invoker for {} at {}.", trigger.getId(), execution.getScheduledFireTime());
             return invokeDelegate(execution).whenComplete((v, t) -> {
                 // whenComplete's callback may run on a different thread than this call (a genuinely async delegate)
-                // - re-establish the identity for that thread rather than assuming it inherited the one above, and
+                // - re-establish the MDC for that thread rather than assuming it inherited the one above, and
                 // always remove it again afterward so a shared, pooled executor thread never leaks it into whatever
                 // unrelated job runs on it next.
-                MDC.put(MDC_IDENTITY_KEY, identity);
+                putMdc(trigger);
                 try {
                     if (t != null) {
-                        log.error("Error occurred while executing task for trigger {}", execution.getTrigger(), t);
+                        log.error("Error occurred while executing task for trigger {}", trigger, t);
                         events.fireJobExecutionFailed(execution, t);
                     } else {
                         events.fireJobExecutionSuccessful(execution);
                     }
                 } finally {
-                    MDC.remove(MDC_IDENTITY_KEY);
+                    removeMdc();
                 }
             });
         } finally {
-            MDC.remove(MDC_IDENTITY_KEY);
+            removeMdc();
         }
+    }
+
+    private static void putMdc(Trigger trigger) {
+        MDC.put(MDC_IDENTITY_KEY, trigger.getId());
+        trigger.getDecisionStrategy().ifPresent(strategy -> MDC.put(MDC_STRATEGY_KEY, strategy.name()));
+        String zone = trigger.getCarbonIntensityZone();
+        if (zone != null) {
+            MDC.put(MDC_ZONE_KEY, zone);
+        }
+    }
+
+    private static void removeMdc() {
+        MDC.remove(MDC_IDENTITY_KEY);
+        MDC.remove(MDC_STRATEGY_KEY);
+        MDC.remove(MDC_ZONE_KEY);
     }
 
 }

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/StatusEmitterInvoker.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/StatusEmitterInvoker.java
@@ -4,7 +4,6 @@ import java.util.concurrent.CompletionStage;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 
 import io.carbonintensity.scheduler.ScheduledExecution;
 import io.carbonintensity.scheduler.Trigger;
@@ -12,15 +11,12 @@ import io.carbonintensity.scheduler.Trigger;
 /**
  * An invoker wrapper that fires events when an execution of a scheduled method is finished.
  * <p>
- * Also the wrapping point for MDC enrichment: every log line emitted during a job's invocation carries the job's
- * {@code identity}, {@code strategy} and {@code zone} (the same three canonical field names CIIO-282's metric tags
- * already use), without every log statement in the invoker chain needing to pass them explicitly.
+ * MDC enrichment (the job's {@code identity}/{@code strategy}/{@code zone}) is handled by
+ * {@link MdcEnrichingInvoker}, which wraps the whole invoker chain from the outside - not here. This class only
+ * re-establishes it, defensively, right before its own completion-time logging below, in case that runs on a
+ * different thread than the one {@link MdcEnrichingInvoker} originally set it on.
  */
 public final class StatusEmitterInvoker extends DelegateInvoker {
-
-    private static final String MDC_IDENTITY_KEY = "identity";
-    private static final String MDC_STRATEGY_KEY = "strategy";
-    private static final String MDC_ZONE_KEY = "zone";
 
     private static final Logger log = LoggerFactory.getLogger(StatusEmitterInvoker.class);
     private final Events events;
@@ -33,44 +29,16 @@ public final class StatusEmitterInvoker extends DelegateInvoker {
     @Override
     public CompletionStage<Void> invoke(ScheduledExecution execution) {
         Trigger trigger = execution.getTrigger();
-        putMdc(trigger);
-        try {
-            log.trace("Running status emitter invoker for {} at {}.", trigger.getId(), execution.getScheduledFireTime());
-            return invokeDelegate(execution).whenComplete((v, t) -> {
-                // whenComplete's callback may run on a different thread than this call (a genuinely async delegate)
-                // - re-establish the MDC for that thread rather than assuming it inherited the one above, and
-                // always remove it again afterward so a shared, pooled executor thread never leaks it into whatever
-                // unrelated job runs on it next.
-                putMdc(trigger);
-                try {
-                    if (t != null) {
-                        log.error("Error occurred while executing task for trigger {}", trigger, t);
-                        events.fireJobExecutionFailed(execution, t);
-                    } else {
-                        events.fireJobExecutionSuccessful(execution);
-                    }
-                } finally {
-                    removeMdc();
-                }
-            });
-        } finally {
-            removeMdc();
-        }
-    }
-
-    private static void putMdc(Trigger trigger) {
-        MDC.put(MDC_IDENTITY_KEY, trigger.getId());
-        trigger.getDecisionStrategy().ifPresent(strategy -> MDC.put(MDC_STRATEGY_KEY, strategy.name()));
-        String zone = trigger.getCarbonIntensityZone();
-        if (zone != null) {
-            MDC.put(MDC_ZONE_KEY, zone);
-        }
-    }
-
-    private static void removeMdc() {
-        MDC.remove(MDC_IDENTITY_KEY);
-        MDC.remove(MDC_STRATEGY_KEY);
-        MDC.remove(MDC_ZONE_KEY);
+        log.trace("Running status emitter invoker for {} at {}.", trigger.getId(), execution.getScheduledFireTime());
+        return invokeDelegate(execution).whenComplete((v, t) -> {
+            MdcEnrichingInvoker.putMdc(trigger);
+            if (t != null) {
+                log.error("Error occurred while executing task for trigger {}", trigger, t);
+                events.fireJobExecutionFailed(execution, t);
+            } else {
+                events.fireJobExecutionSuccessful(execution);
+            }
+        });
     }
 
 }

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/StatusEmitterInvoker.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/StatusEmitterInvoker.java
@@ -10,11 +10,6 @@ import io.carbonintensity.scheduler.Trigger;
 
 /**
  * An invoker wrapper that fires events when an execution of a scheduled method is finished.
- * <p>
- * MDC enrichment (the job's {@code identity}/{@code strategy}/{@code zone}) is handled by
- * {@link MdcEnrichingInvoker}, which wraps the whole invoker chain from the outside - not here. This class only
- * re-establishes it, defensively, right before its own completion-time logging below, in case that runs on a
- * different thread than the one {@link MdcEnrichingInvoker} originally set it on.
  */
 public final class StatusEmitterInvoker extends DelegateInvoker {
 
@@ -29,8 +24,11 @@ public final class StatusEmitterInvoker extends DelegateInvoker {
     @Override
     public CompletionStage<Void> invoke(ScheduledExecution execution) {
         Trigger trigger = execution.getTrigger();
-        log.trace("Running status emitter invoker for {} at {}.", trigger.getId(), execution.getScheduledFireTime());
+        if (log.isTraceEnabled()) {
+            log.trace("Running status emitter invoker for {} at {}.", trigger.getId(), execution.getScheduledFireTime());
+        }
         return invokeDelegate(execution).whenComplete((v, t) -> {
+            // re-establish MDC in case this runs on a different thread
             MdcEnrichingInvoker.putMdc(trigger);
             if (t != null) {
                 log.error("Error occurred while executing task for trigger {}", trigger, t);

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/StatusEmitterInvoker.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/StatusEmitterInvoker.java
@@ -4,13 +4,20 @@ import java.util.concurrent.CompletionStage;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import io.carbonintensity.scheduler.ScheduledExecution;
 
 /**
  * An invoker wrapper that fires events when an execution of a scheduled method is finished.
+ * <p>
+ * Also the wrapping point for MDC enrichment: every log line emitted during a job's invocation carries the job's
+ * {@code identity} (the canonical field name, matching what the metrics/decision-timeline machinery already uses),
+ * without every log statement in the invoker chain needing to pass it explicitly.
  */
 public final class StatusEmitterInvoker extends DelegateInvoker {
+
+    private static final String MDC_IDENTITY_KEY = "identity";
 
     private static final Logger log = LoggerFactory.getLogger(StatusEmitterInvoker.class);
     private final Events events;
@@ -22,16 +29,30 @@ public final class StatusEmitterInvoker extends DelegateInvoker {
 
     @Override
     public CompletionStage<Void> invoke(ScheduledExecution execution) {
-        log.trace("Running status emitter invoker for {} at {}.", execution.getTrigger().getId(),
-                execution.getScheduledFireTime());
-        return invokeDelegate(execution).whenComplete((v, t) -> {
-            if (t != null) {
-                log.error("Error occurred while executing task for trigger {}", execution.getTrigger(), t);
-                events.fireJobExecutionFailed(execution, t);
-            } else {
-                events.fireJobExecutionSuccessful(execution);
-            }
-        });
+        String identity = execution.getTrigger().getId();
+        MDC.put(MDC_IDENTITY_KEY, identity);
+        try {
+            log.trace("Running status emitter invoker for {} at {}.", identity, execution.getScheduledFireTime());
+            return invokeDelegate(execution).whenComplete((v, t) -> {
+                // whenComplete's callback may run on a different thread than this call (a genuinely async delegate)
+                // - re-establish the identity for that thread rather than assuming it inherited the one above, and
+                // always remove it again afterward so a shared, pooled executor thread never leaks it into whatever
+                // unrelated job runs on it next.
+                MDC.put(MDC_IDENTITY_KEY, identity);
+                try {
+                    if (t != null) {
+                        log.error("Error occurred while executing task for trigger {}", execution.getTrigger(), t);
+                        events.fireJobExecutionFailed(execution, t);
+                    } else {
+                        events.fireJobExecutionSuccessful(execution);
+                    }
+                } finally {
+                    MDC.remove(MDC_IDENTITY_KEY);
+                }
+            });
+        } finally {
+            MDC.remove(MDC_IDENTITY_KEY);
+        }
     }
 
 }

--- a/core/src/test/java/io/carbonintensity/scheduler/runtime/DecisionTimelineWiringTest.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/runtime/DecisionTimelineWiringTest.java
@@ -1,0 +1,234 @@
+package io.carbonintensity.scheduler.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+
+import io.carbonintensity.scheduler.GreenScheduled;
+import io.carbonintensity.scheduler.Scheduler;
+import io.carbonintensity.scheduler.Trigger;
+import io.carbonintensity.scheduler.observability.DecisionReason;
+import io.carbonintensity.scheduler.observability.DecisionStrategy;
+import io.carbonintensity.scheduler.observability.DecisionTimelineEntry;
+import io.carbonintensity.scheduler.observability.DecisionTimelineStore;
+import io.carbonintensity.scheduler.test.helper.AnnotationUtil;
+import io.carbonintensity.scheduler.test.helper.DisabledDummyCarbonIntensityApi;
+import io.carbonintensity.scheduler.test.helper.MutableClock;
+
+/**
+ * Verifies the decision timeline is wired end to end through the real {@link SimpleScheduler} tick (not a manual
+ * {@code recordDecision} call) - a real fire produces a correctly-populated {@link DecisionTimelineEntry} via both
+ * the configured {@link DecisionTimelineStore} and the {@link Scheduler.EventListener#jobDecisionRecorded} event -
+ * plus the two safety properties recording must uphold: a storage failure never blocks the job itself, and the MDC
+ * identity never leaks across jobs sharing the same pooled executor thread.
+ */
+class DecisionTimelineWiringTest {
+
+    private SimpleScheduler scheduler;
+
+    @AfterEach
+    void afterEach() {
+        if (scheduler != null) {
+            scheduler.close();
+        }
+    }
+
+    @Test
+    void aRealFixedWindowFireRecordsADecisionTimelineEntry() throws Exception {
+        CopyOnWriteArrayList<DecisionTimelineEntry> storedEntries = new CopyOnWriteArrayList<>();
+        CopyOnWriteArrayList<DecisionTimelineEntry> firedEvents = new CopyOnWriteArrayList<>();
+        DecisionTimelineStore recordingStore = new DecisionTimelineStore() {
+            @Override
+            public void record(String identity, DecisionTimelineEntry entry) {
+                storedEntries.add(entry);
+            }
+
+            @Override
+            public List<DecisionTimelineEntry> entriesFor(String identity) {
+                return List.copyOf(storedEntries);
+            }
+        };
+
+        SchedulerConfig config = new SchedulerConfig();
+        config.setCarbonIntensityApi(new DisabledDummyCarbonIntensityApi());
+        config.setDecisionTimelineStore(recordingStore);
+
+        // Same fixture as TestFixedWindowScheduler: with the fallback file dataset, "05:15 08:15" consistently
+        // resolves its greenest slot to 07:15 Europe/Amsterdam - shifting from 04:16 to 07:16 crosses it.
+        MutableClock mutableClock = new MutableClock(Clock.fixed(
+                ZonedDateTime.of(LocalDateTime.of(LocalDate.of(2024, 6, 1), LocalTime.of(4, 16)), ZoneId.of("Europe/Amsterdam"))
+                        .toInstant(),
+                ZoneId.of("UTC")));
+        config.setClock(mutableClock);
+
+        scheduler = new SimpleScheduler(config);
+        scheduler.addJobListener(new Scheduler.EventListener() {
+            @Override
+            public void jobDecisionRecorded(Trigger trigger, DecisionTimelineEntry entry) {
+                firedEvents.add(entry);
+            }
+        });
+
+        GreenScheduled greenScheduled = AnnotationUtil.newGreenScheduled()
+                .fixedWindow("05:15 08:15")
+                .carbonIntensityZone("NL")
+                .duration("2h")
+                .identity("test")
+                .timeZone("Europe/Amsterdam")
+                .build();
+        scheduler.scheduleMethod(
+                new ImmutableScheduledMethod(noopInvoker(), getClass().getName(), "test", List.of(greenScheduled)));
+        mutableClock.getNotifier().register(scheduler);
+        scheduler.start();
+
+        mutableClock.shift(java.time.Duration.ofHours(3));
+
+        Awaitility.await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> assertThat(storedEntries).hasSize(1));
+
+        DecisionTimelineEntry entry = storedEntries.get(0);
+        assertThat(entry.strategy()).isEqualTo(DecisionStrategy.FIXED_WINDOW);
+        assertThat(entry.reason()).isEqualTo(DecisionReason.GREENEST_AVAILABLE_SLOT);
+        assertThat(entry.intensityValue()).isEmpty();
+        assertThat(firedEvents).containsExactly(entry);
+    }
+
+    @Test
+    void aStorageFailureIsCaughtAndDoesNotPreventTheJobFromRunning() throws Exception {
+        DecisionTimelineStore throwingStore = new DecisionTimelineStore() {
+            @Override
+            public void record(String identity, DecisionTimelineEntry entry) {
+                throw new RuntimeException("simulated storage failure");
+            }
+
+            @Override
+            public List<DecisionTimelineEntry> entriesFor(String identity) {
+                return List.of();
+            }
+        };
+
+        SchedulerConfig config = new SchedulerConfig();
+        config.setCarbonIntensityApi(new DisabledDummyCarbonIntensityApi());
+        config.setDecisionTimelineStore(throwingStore);
+
+        MutableClock mutableClock = new MutableClock(Clock.fixed(
+                ZonedDateTime.of(LocalDateTime.of(LocalDate.of(2024, 6, 1), LocalTime.of(4, 16)), ZoneId.of("Europe/Amsterdam"))
+                        .toInstant(),
+                ZoneId.of("UTC")));
+        config.setClock(mutableClock);
+
+        CountDownLatch jobRan = new CountDownLatch(1);
+        scheduler = new SimpleScheduler(config);
+        GreenScheduled greenScheduled = AnnotationUtil.newGreenScheduled()
+                .fixedWindow("05:15 08:15")
+                .carbonIntensityZone("NL")
+                .duration("2h")
+                .identity("test")
+                .timeZone("Europe/Amsterdam")
+                .build();
+        scheduler.scheduleMethod(new ImmutableScheduledMethod(execution -> {
+            jobRan.countDown();
+            return CompletableFuture.completedFuture(null);
+        }, getClass().getName(), "test", List.of(greenScheduled)));
+        mutableClock.getNotifier().register(scheduler);
+        scheduler.start();
+
+        mutableClock.shift(java.time.Duration.ofHours(3));
+
+        assertThat(jobRan.await(2, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    void mdcIdentityDoesNotLeakAcrossJobsOnTheSamePooledThread() throws Exception {
+        SchedulerConfig config = new SchedulerConfig();
+        config.setCarbonIntensityApi(new DisabledDummyCarbonIntensityApi());
+        config.setJobExecutors(1); // force both jobs below onto the exact same executor thread
+
+        MutableClock mutableClock = new MutableClock(Clock.fixed(
+                ZonedDateTime.of(LocalDateTime.of(LocalDate.of(2024, 6, 1), LocalTime.of(4, 16)), ZoneId.of("Europe/Amsterdam"))
+                        .toInstant(),
+                ZoneId.of("UTC")));
+        config.setClock(mutableClock);
+        scheduler = new SimpleScheduler(config);
+
+        CopyOnWriteArrayList<String> observedIdentityA = new CopyOnWriteArrayList<>();
+        CopyOnWriteArrayList<String> observedIdentityB = new CopyOnWriteArrayList<>();
+        CountDownLatch jobADone = new CountDownLatch(1);
+        CountDownLatch jobBDone = new CountDownLatch(1);
+
+        GreenScheduled jobA = AnnotationUtil.newGreenScheduled()
+                .fixedWindow("05:15 08:15").carbonIntensityZone("NL").duration("2h")
+                .identity("job-a").timeZone("Europe/Amsterdam").build();
+        scheduler.scheduleMethod(new ImmutableScheduledMethod(execution -> {
+            observedIdentityA.add(MDC.get("identity"));
+            jobADone.countDown();
+            return CompletableFuture.completedFuture(null);
+        }, getClass().getName(), "job-a", List.of(jobA)));
+
+        mutableClock.getNotifier().register(scheduler);
+        scheduler.start();
+        mutableClock.shift(java.time.Duration.ofHours(3)); // fires job-a at 07:16
+        assertThat(jobADone.await(2, TimeUnit.SECONDS)).isTrue();
+
+        // a second, differently-identified job registered right after, targeting the same (still-open) window -
+        // its greenest slot (deterministically the same 07:15, per the fallback dataset) is already in the past
+        // relative to "now", so it fires as soon as triggers are checked again - still the same single-thread pool
+        GreenScheduled jobB = AnnotationUtil.newGreenScheduled()
+                .fixedWindow("05:15 08:15").carbonIntensityZone("NL").duration("2h")
+                .identity("job-b").timeZone("Europe/Amsterdam").build();
+        scheduler.scheduleMethod(new ImmutableScheduledMethod(execution -> {
+            observedIdentityB.add(MDC.get("identity"));
+            jobBDone.countDown();
+            return CompletableFuture.completedFuture(null);
+        }, getClass().getName(), "job-b", List.of(jobB)));
+
+        mutableClock.shift(java.time.Duration.ZERO); // force a synchronous checkTriggers() at the current time
+        assertThat(jobBDone.await(2, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(observedIdentityA).containsExactly("job-a");
+        assertThat(observedIdentityB).containsExactly("job-b"); // not "job-a" - proves no leak onto the shared thread
+    }
+
+    @Test
+    void simpleTriggerStrategyThrowsByDefaultUnlessOverridden() {
+        SimpleScheduler.SimpleTrigger noStrategyTrigger = new SimpleScheduler.SimpleTrigger("no-strategy",
+                Clock.systemUTC(), ZonedDateTime.now(), "test") {
+            @Override
+            ZonedDateTime evaluate(ZonedDateTime now) {
+                return null;
+            }
+
+            @Override
+            public Instant getNextFireTime() {
+                return null;
+            }
+
+            @Override
+            public boolean isOverdue() {
+                return false;
+            }
+        };
+
+        assertThatThrownBy(noStrategyTrigger::strategy).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    private ScheduledInvoker noopInvoker() {
+        return execution -> CompletableFuture.completedFuture(null);
+    }
+}

--- a/core/src/test/java/io/carbonintensity/scheduler/runtime/DecisionTimelineWiringTest.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/runtime/DecisionTimelineWiringTest.java
@@ -227,7 +227,7 @@ class DecisionTimelineWiringTest {
         SimpleScheduler.SimpleTrigger noStrategyTrigger = new SimpleScheduler.SimpleTrigger("no-strategy",
                 Clock.systemUTC(), ZonedDateTime.now(), "test") {
             @Override
-            ZonedDateTime evaluate(ZonedDateTime now) {
+            SimpleScheduler.EvaluationResult evaluate(ZonedDateTime now) {
                 return null;
             }
 
@@ -242,7 +242,7 @@ class DecisionTimelineWiringTest {
             }
         };
 
-        assertThat(noStrategyTrigger.getDecisionStrategy()).isEmpty();
+        assertThat(noStrategyTrigger.getDecisionStrategy()).isNull();
     }
 
     private ScheduledInvoker noopInvoker() {

--- a/core/src/test/java/io/carbonintensity/scheduler/runtime/DecisionTimelineWiringTest.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/runtime/DecisionTimelineWiringTest.java
@@ -172,7 +172,11 @@ class DecisionTimelineWiringTest {
         scheduler = new SimpleScheduler(config);
 
         CopyOnWriteArrayList<String> observedIdentityA = new CopyOnWriteArrayList<>();
+        CopyOnWriteArrayList<String> observedStrategyA = new CopyOnWriteArrayList<>();
+        CopyOnWriteArrayList<String> observedZoneA = new CopyOnWriteArrayList<>();
         CopyOnWriteArrayList<String> observedIdentityB = new CopyOnWriteArrayList<>();
+        CopyOnWriteArrayList<String> observedStrategyB = new CopyOnWriteArrayList<>();
+        CopyOnWriteArrayList<String> observedZoneB = new CopyOnWriteArrayList<>();
         CountDownLatch jobADone = new CountDownLatch(1);
         CountDownLatch jobBDone = new CountDownLatch(1);
 
@@ -181,6 +185,8 @@ class DecisionTimelineWiringTest {
                 .identity("job-a").timeZone("Europe/Amsterdam").build();
         scheduler.scheduleMethod(new ImmutableScheduledMethod(execution -> {
             observedIdentityA.add(MDC.get("identity"));
+            observedStrategyA.add(MDC.get("strategy"));
+            observedZoneA.add(MDC.get("zone"));
             jobADone.countDown();
             return CompletableFuture.completedFuture(null);
         }, getClass().getName(), "job-a", List.of(jobA)));
@@ -192,12 +198,15 @@ class DecisionTimelineWiringTest {
 
         // a second, differently-identified job registered right after, targeting the same (still-open) window -
         // its greenest slot (deterministically the same 07:15, per the fallback dataset) is already in the past
-        // relative to "now", so it fires as soon as triggers are checked again - still the same single-thread pool
+        // relative to "now", so it fires as soon as triggers are checked again - still the same single-thread pool.
+        // Uses a different zone than job-a so a leaked MDC value would be caught, not just a coincidental match.
         GreenScheduled jobB = AnnotationUtil.newGreenScheduled()
-                .fixedWindow("05:15 08:15").carbonIntensityZone("NL").duration("2h")
+                .fixedWindow("05:15 08:15").carbonIntensityZone("DE").duration("2h")
                 .identity("job-b").timeZone("Europe/Amsterdam").build();
         scheduler.scheduleMethod(new ImmutableScheduledMethod(execution -> {
             observedIdentityB.add(MDC.get("identity"));
+            observedStrategyB.add(MDC.get("strategy"));
+            observedZoneB.add(MDC.get("zone"));
             jobBDone.countDown();
             return CompletableFuture.completedFuture(null);
         }, getClass().getName(), "job-b", List.of(jobB)));
@@ -207,6 +216,10 @@ class DecisionTimelineWiringTest {
 
         assertThat(observedIdentityA).containsExactly("job-a");
         assertThat(observedIdentityB).containsExactly("job-b"); // not "job-a" - proves no leak onto the shared thread
+        assertThat(observedStrategyA).containsExactly("FIXED_WINDOW");
+        assertThat(observedStrategyB).containsExactly("FIXED_WINDOW");
+        assertThat(observedZoneA).containsExactly("NL");
+        assertThat(observedZoneB).containsExactly("DE"); // not "NL" - proves no leak onto the shared thread
     }
 
     @Test

--- a/core/src/test/java/io/carbonintensity/scheduler/runtime/DecisionTimelineWiringTest.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/runtime/DecisionTimelineWiringTest.java
@@ -1,7 +1,6 @@
 package io.carbonintensity.scheduler.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -105,7 +104,12 @@ class DecisionTimelineWiringTest {
         DecisionTimelineEntry entry = storedEntries.get(0);
         assertThat(entry.strategy()).isEqualTo(DecisionStrategy.FIXED_WINDOW);
         assertThat(entry.reason()).isEqualTo(DecisionReason.GREENEST_AVAILABLE_SLOT);
-        assertThat(entry.intensityValue()).isEmpty();
+        // a carbon-aware fire (as opposed to a fallback cron/interval fire, which never queried a planner)
+        // must carry the real value the planner used to pick this slot - never a fabricated one. The exact
+        // number is the planner's own responsibility to get right (see TestFixedWindowPlanner); this just
+        // proves it is no longer discarded on the way into the decision-timeline entry.
+        assertThat(entry.intensityValue()).isPresent();
+        assertThat(entry.intensityValue().getAsDouble()).isGreaterThan(0);
         assertThat(firedEvents).containsExactly(entry);
     }
 
@@ -206,7 +210,7 @@ class DecisionTimelineWiringTest {
     }
 
     @Test
-    void simpleTriggerStrategyThrowsByDefaultUnlessOverridden() {
+    void simpleTriggerHasNoDecisionStrategyByDefaultUnlessOverridden() {
         SimpleScheduler.SimpleTrigger noStrategyTrigger = new SimpleScheduler.SimpleTrigger("no-strategy",
                 Clock.systemUTC(), ZonedDateTime.now(), "test") {
             @Override
@@ -225,7 +229,7 @@ class DecisionTimelineWiringTest {
             }
         };
 
-        assertThatThrownBy(noStrategyTrigger::strategy).isInstanceOf(UnsupportedOperationException.class);
+        assertThat(noStrategyTrigger.getDecisionStrategy()).isEmpty();
     }
 
     private ScheduledInvoker noopInvoker() {

--- a/core/src/test/java/io/carbonintensity/scheduler/runtime/InMemoryDecisionTimelineStoreTest.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/runtime/InMemoryDecisionTimelineStoreTest.java
@@ -94,6 +94,22 @@ class InMemoryDecisionTimelineStoreTest {
     }
 
     @Test
+    void staysCorrectWhenEntriesArriveOutOfOrder() {
+        // record() carries no ordering precondition - an out-of-order arrival must not fool age-based eviction
+        // (which only ever inspects the front of the list) into keeping a genuinely-too-old entry buried
+        // elsewhere, or evicting a young one instead
+        Instant now = BASE.plus(Duration.ofDays(40));
+        InMemoryDecisionTimelineStore store = newStore(now, Duration.ofDays(30), 100);
+
+        store.record("job-a", entryAt(BASE.plus(Duration.ofDays(35)))); // within window, kept - arrives first
+        store.record("job-a", entryAt(BASE.plus(Duration.ofDays(5)))); // too old, evicted - arrives out of order
+        store.record("job-a", entryAt(BASE.plus(Duration.ofDays(15)))); // within window, kept
+
+        assertThat(store.entriesFor("job-a")).extracting(DecisionTimelineEntry::fireTime)
+                .containsExactly(BASE.plus(Duration.ofDays(15)), BASE.plus(Duration.ofDays(35)));
+    }
+
+    @Test
     void rejectsANonPositiveMaxEntriesPerJob() {
         assertThatThrownBy(() -> newStore(BASE, Duration.ofDays(30), 0))
                 .isInstanceOf(IllegalArgumentException.class);

--- a/core/src/test/java/io/carbonintensity/scheduler/runtime/InMemoryDecisionTimelineStoreTest.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/runtime/InMemoryDecisionTimelineStoreTest.java
@@ -1,0 +1,110 @@
+package io.carbonintensity.scheduler.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.OptionalDouble;
+
+import org.junit.jupiter.api.Test;
+
+import io.carbonintensity.scheduler.observability.DecisionReason;
+import io.carbonintensity.scheduler.observability.DecisionStrategy;
+import io.carbonintensity.scheduler.observability.DecisionTimelineEntry;
+
+class InMemoryDecisionTimelineStoreTest {
+
+    private static final Instant BASE = Instant.parse("2026-01-01T00:00:00Z");
+
+    @Test
+    void entriesForUnknownIdentityIsEmpty() {
+        InMemoryDecisionTimelineStore store = newStore(BASE, Duration.ofDays(30), 100);
+
+        assertThat(store.entriesFor("unknown")).isEmpty();
+    }
+
+    @Test
+    void recordsAndReturnsEntriesOldestFirst() {
+        InMemoryDecisionTimelineStore store = newStore(BASE, Duration.ofDays(30), 100);
+
+        store.record("job-a", entryAt(BASE));
+        store.record("job-a", entryAt(BASE.plusSeconds(60)));
+
+        List<DecisionTimelineEntry> entries = store.entriesFor("job-a");
+        assertThat(entries).hasSize(2);
+        assertThat(entries.get(0).fireTime()).isEqualTo(BASE);
+        assertThat(entries.get(1).fireTime()).isEqualTo(BASE.plusSeconds(60));
+    }
+
+    @Test
+    void keepsDifferentJobsIsolated() {
+        InMemoryDecisionTimelineStore store = newStore(BASE, Duration.ofDays(30), 100);
+
+        store.record("job-a", entryAt(BASE));
+        store.record("job-b", entryAt(BASE));
+        store.record("job-b", entryAt(BASE.plusSeconds(1)));
+
+        assertThat(store.entriesFor("job-a")).hasSize(1);
+        assertThat(store.entriesFor("job-b")).hasSize(2);
+    }
+
+    @Test
+    void evictsEntriesOlderThanTheRetentionWindow() {
+        // clock fixed at day 40 - entries older than 30 days (i.e. before day 10) should be pruned
+        Instant now = BASE.plus(Duration.ofDays(40));
+        InMemoryDecisionTimelineStore store = newStore(now, Duration.ofDays(30), 100);
+
+        store.record("job-a", entryAt(BASE.plus(Duration.ofDays(5)))); // too old, evicted
+        store.record("job-a", entryAt(BASE.plus(Duration.ofDays(15)))); // within window, kept
+        store.record("job-a", entryAt(BASE.plus(Duration.ofDays(35)))); // within window, kept
+
+        List<DecisionTimelineEntry> entries = store.entriesFor("job-a");
+        assertThat(entries).extracting(DecisionTimelineEntry::fireTime)
+                .containsExactly(BASE.plus(Duration.ofDays(15)), BASE.plus(Duration.ofDays(35)));
+    }
+
+    @Test
+    void evictsOldestWhenTheEntryCountCapIsExceeded() {
+        InMemoryDecisionTimelineStore store = newStore(BASE, Duration.ofDays(30), 3);
+
+        for (int i = 0; i < 5; i++) {
+            store.record("job-a", entryAt(BASE.plusSeconds(i)));
+        }
+
+        List<DecisionTimelineEntry> entries = store.entriesFor("job-a");
+        assertThat(entries).hasSize(3);
+        assertThat(entries).extracting(DecisionTimelineEntry::fireTime)
+                .containsExactly(BASE.plusSeconds(2), BASE.plusSeconds(3), BASE.plusSeconds(4));
+    }
+
+    @Test
+    void bothCapsApplyTogetherWhicheverIsHitFirst() {
+        // a 2-day retention window, but a count cap of 1 - the count cap bites first here
+        InMemoryDecisionTimelineStore store = newStore(BASE, Duration.ofDays(2), 1);
+
+        store.record("job-a", entryAt(BASE));
+        store.record("job-a", entryAt(BASE.plusSeconds(1)));
+
+        assertThat(store.entriesFor("job-a")).extracting(DecisionTimelineEntry::fireTime)
+                .containsExactly(BASE.plusSeconds(1));
+    }
+
+    @Test
+    void rejectsANonPositiveMaxEntriesPerJob() {
+        assertThatThrownBy(() -> newStore(BASE, Duration.ofDays(30), 0))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static InMemoryDecisionTimelineStore newStore(Instant now, Duration retention, int maxEntriesPerJob) {
+        return new InMemoryDecisionTimelineStore(Clock.fixed(now, ZoneOffset.UTC), retention, maxEntriesPerJob);
+    }
+
+    private static DecisionTimelineEntry entryAt(Instant fireTime) {
+        return new DecisionTimelineEntry(fireTime, DecisionStrategy.FIXED_WINDOW, DecisionReason.GREENEST_AVAILABLE_SLOT,
+                OptionalDouble.empty());
+    }
+}

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.carbonintensity" level="DEBUG"/>
+    <logger name="ai.timefold.solver" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/core/src/test/resources/simplelogger.properties
+++ b/core/src/test/resources/simplelogger.properties
@@ -1,5 +1,0 @@
-org.slf4j.simpleLogger.defaultLogLevel=info
-org.slf4j.simpleLogger.log.io.carbonintensity=debug
-org.slf4j.simpleLogger.log.ai.timefold.solver=debug
-org.slf4j.simpleLogger.showDateTime=true
-org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss.SSS

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/Timeslot.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/Timeslot.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensity;
 
@@ -17,6 +18,10 @@ import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensity;
 public class Timeslot {
     ZonedDateTime start;
     ZonedDateTime end;
+    /**
+     * {@code null} when no {@link CarbonIntensityPeriod} overlapped this slot at all - a genuine data gap, never
+     * to be confused with a real zero-intensity slot.
+     */
     BigDecimal carbonIntensity;
 
     public Timeslot(ZonedDateTime start, ZonedDateTime end, BigDecimal carbonIntensity) {
@@ -33,6 +38,10 @@ public class Timeslot {
         return end;
     }
 
+    /**
+     * @return the carbon-intensity value for this slot, or {@code null} if no data was available to compute one -
+     *         never a sentinel like {@link BigDecimal#ZERO} standing in for "unknown"
+     */
     public BigDecimal carbonIntensity() {
         return carbonIntensity;
     }
@@ -57,19 +66,30 @@ public class Timeslot {
 
         while (!s.isAfter(we)) { // allow equal for 0 windows
             ZonedDateTime e = s.plus(timeslotDuration);
-            timeslots.add(new Timeslot(s, e, calculateCarbonIntensity(periods, s, e)));
+            timeslots.add(new Timeslot(s, e, calculateCarbonIntensity(periods, s, e).orElse(null)));
             s = s.plus(resolution);
         }
         return timeslots;
     }
 
-    public static BigDecimal calculateCarbonIntensity(List<CarbonIntensityPeriod> carbonIntensityInstants, ZonedDateTime start,
-            ZonedDateTime end) {
-        // find carbon intensities.
-        return carbonIntensityInstants.stream()
+    /**
+     * @return the summed carbon-intensity contribution of every {@link CarbonIntensityPeriod} overlapping
+     *         {@code [start, end]}, or {@link Optional#empty()} if none overlapped at all - distinguishing a
+     *         genuine data gap from a real zero, which {@link BigDecimal#ZERO} as a reduce identity could not
+     */
+    public static Optional<BigDecimal> calculateCarbonIntensity(List<CarbonIntensityPeriod> carbonIntensityInstants,
+            ZonedDateTime start, ZonedDateTime end) {
+        List<CarbonIntensityPeriod> overlapping = carbonIntensityInstants.stream()
                 .filter(m -> m.contains(start.toInstant()) || m.contains(end.toInstant()))
-                .map(ci -> calculateCarbonIntensity(start, end, ci))
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
+                .toList();
+        if (overlapping.isEmpty()) {
+            return Optional.empty();
+        }
+        BigDecimal sum = BigDecimal.ZERO;
+        for (CarbonIntensityPeriod ci : overlapping) {
+            sum = sum.add(calculateCarbonIntensity(start, end, ci));
+        }
+        return Optional.of(sum);
     }
 
     private static BigDecimal calculateCarbonIntensity(ZonedDateTime start, ZonedDateTime end, CarbonIntensityPeriod ci) {

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/Timeslot.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/Timeslot.java
@@ -79,17 +79,15 @@ public class Timeslot {
      */
     public static Optional<BigDecimal> calculateCarbonIntensity(List<CarbonIntensityPeriod> carbonIntensityInstants,
             ZonedDateTime start, ZonedDateTime end) {
-        List<CarbonIntensityPeriod> overlapping = carbonIntensityInstants.stream()
-                .filter(m -> m.contains(start.toInstant()) || m.contains(end.toInstant()))
-                .toList();
-        if (overlapping.isEmpty()) {
-            return Optional.empty();
-        }
         BigDecimal sum = BigDecimal.ZERO;
-        for (CarbonIntensityPeriod ci : overlapping) {
-            sum = sum.add(calculateCarbonIntensity(start, end, ci));
+        boolean found = false;
+        for (CarbonIntensityPeriod ci : carbonIntensityInstants) {
+            if (ci.contains(start.toInstant()) || ci.contains(end.toInstant())) {
+                sum = sum.add(calculateCarbonIntensity(start, end, ci));
+                found = true;
+            }
         }
-        return Optional.of(sum);
+        return found ? Optional.of(sum) : Optional.empty();
     }
 
     private static BigDecimal calculateCarbonIntensity(ZonedDateTime start, ZonedDateTime end, CarbonIntensityPeriod ci) {

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/fixedwindow/FixedWindowPlanner.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/fixedwindow/FixedWindowPlanner.java
@@ -2,7 +2,6 @@ package io.carbonintensity.executionplanner.planner.fixedwindow;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,7 +85,7 @@ public class FixedWindowPlanner implements CarbonIntensityPlanner<FixedWindowPla
         if (slotTracker == null || maxConcurrentPerSlot <= 0) {
             Timeslot best = strategy.bestTimeslot(constraints.getStart(), constraints.getEnd(), constraints.getDuration(),
                     carbonIntensity);
-            return best == null ? null : toPlannedExecution(best);
+            return best == null ? null : PlannedExecution.from(best);
         }
 
         return pickTimeslot(strategy, constraints, carbonIntensity);
@@ -104,7 +103,7 @@ public class FixedWindowPlanner implements CarbonIntensityPlanner<FixedWindowPla
         String identity = constraints.getIdentity();
         for (Timeslot candidate : ranked) {
             if (slotTracker.tryReserve(zone, identity, candidate.start().toInstant(), maxConcurrentPerSlot)) {
-                return toPlannedExecution(candidate);
+                return PlannedExecution.from(candidate);
             }
         }
 
@@ -115,10 +114,6 @@ public class FixedWindowPlanner implements CarbonIntensityPlanner<FixedWindowPla
                 "Concurrency limit of {} per slot exceeded for zone {} at {} - scheduling '{}' anyway to honor its fixed window",
                 maxConcurrentPerSlot, zone, best.start(), identity);
         slotTracker.reserve(zone, identity, best.start().toInstant());
-        return toPlannedExecution(best);
-    }
-
-    private static PlannedExecution toPlannedExecution(Timeslot timeslot) {
-        return new PlannedExecution(timeslot.start(), Optional.ofNullable(timeslot.carbonIntensity()));
+        return PlannedExecution.from(best);
     }
 }

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/fixedwindow/FixedWindowPlanner.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/fixedwindow/FixedWindowPlanner.java
@@ -1,8 +1,8 @@
 package io.carbonintensity.executionplanner.planner.fixedwindow;
 
 import java.time.Duration;
-import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,6 +13,7 @@ import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensityDataFetch
 import io.carbonintensity.executionplanner.runtime.impl.ZonedCarbonIntensityPeriod;
 import io.carbonintensity.executionplanner.spi.CarbonIntensityPlanner;
 import io.carbonintensity.executionplanner.spi.ConcurrencySlotTracker;
+import io.carbonintensity.executionplanner.spi.PlannedExecution;
 import io.carbonintensity.executionplanner.strategy.SingleJobStrategy;
 
 /**
@@ -71,7 +72,7 @@ public class FixedWindowPlanner implements CarbonIntensityPlanner<FixedWindowPla
     }
 
     @Override
-    public ZonedDateTime getNextExecutionTime(FixedWindowPlanningConstraints constraints) {
+    public PlannedExecution getNextExecutionTime(FixedWindowPlanningConstraints constraints) {
 
         final var period = new ZonedCarbonIntensityPeriod.Builder()
                 .withStartTime(constraints.getStart())
@@ -85,13 +86,13 @@ public class FixedWindowPlanner implements CarbonIntensityPlanner<FixedWindowPla
         if (slotTracker == null || maxConcurrentPerSlot <= 0) {
             Timeslot best = strategy.bestTimeslot(constraints.getStart(), constraints.getEnd(), constraints.getDuration(),
                     carbonIntensity);
-            return best == null ? null : best.start();
+            return best == null ? null : toPlannedExecution(best);
         }
 
         return pickTimeslot(strategy, constraints, carbonIntensity);
     }
 
-    private ZonedDateTime pickTimeslot(SingleJobStrategy strategy, FixedWindowPlanningConstraints constraints,
+    private PlannedExecution pickTimeslot(SingleJobStrategy strategy, FixedWindowPlanningConstraints constraints,
             CarbonIntensity carbonIntensity) {
         List<Timeslot> ranked = strategy.rankedTimeslots(constraints.getStart(), constraints.getEnd(),
                 constraints.getDuration(), carbonIntensity);
@@ -103,7 +104,7 @@ public class FixedWindowPlanner implements CarbonIntensityPlanner<FixedWindowPla
         String identity = constraints.getIdentity();
         for (Timeslot candidate : ranked) {
             if (slotTracker.tryReserve(zone, identity, candidate.start().toInstant(), maxConcurrentPerSlot)) {
-                return candidate.start();
+                return toPlannedExecution(candidate);
             }
         }
 
@@ -114,6 +115,10 @@ public class FixedWindowPlanner implements CarbonIntensityPlanner<FixedWindowPla
                 "Concurrency limit of {} per slot exceeded for zone {} at {} - scheduling '{}' anyway to honor its fixed window",
                 maxConcurrentPerSlot, zone, best.start(), identity);
         slotTracker.reserve(zone, identity, best.start().toInstant());
-        return best.start();
+        return toPlannedExecution(best);
+    }
+
+    private static PlannedExecution toPlannedExecution(Timeslot timeslot) {
+        return new PlannedExecution(timeslot.start(), Optional.ofNullable(timeslot.carbonIntensity()));
     }
 }

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/successive/SuccessivePlanner.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/successive/SuccessivePlanner.java
@@ -2,7 +2,6 @@ package io.carbonintensity.executionplanner.planner.successive;
 
 import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,7 +95,7 @@ public class SuccessivePlanner implements CarbonIntensityPlanner<SuccessivePlann
 
         if (slotTracker == null || maxConcurrentPerSlot <= 0) {
             Timeslot best = strategy.bestTimeslot(ws, we, constraints.getDuration(), carbonIntensity);
-            return best == null ? null : toPlannedExecution(best);
+            return best == null ? null : PlannedExecution.from(best);
         }
 
         return pickTimeslot(strategy, constraints, ws, we, carbonIntensity);
@@ -113,7 +112,7 @@ public class SuccessivePlanner implements CarbonIntensityPlanner<SuccessivePlann
         String identity = constraints.getIdentity();
         for (Timeslot candidate : ranked) {
             if (slotTracker.tryReserve(zone, identity, candidate.start().toInstant(), maxConcurrentPerSlot)) {
-                return toPlannedExecution(candidate);
+                return PlannedExecution.from(candidate);
             }
         }
 
@@ -124,11 +123,7 @@ public class SuccessivePlanner implements CarbonIntensityPlanner<SuccessivePlann
                 "Concurrency limit of {} per slot exceeded for zone {} at {} - scheduling '{}' anyway to honor its gap window",
                 maxConcurrentPerSlot, zone, best.start(), identity);
         slotTracker.reserve(zone, identity, best.start().toInstant());
-        return toPlannedExecution(best);
-    }
-
-    private static PlannedExecution toPlannedExecution(Timeslot timeslot) {
-        return new PlannedExecution(timeslot.start(), Optional.ofNullable(timeslot.carbonIntensity()));
+        return PlannedExecution.from(best);
     }
 
 }

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/successive/SuccessivePlanner.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/planner/successive/SuccessivePlanner.java
@@ -2,6 +2,7 @@ package io.carbonintensity.executionplanner.planner.successive;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,6 +13,7 @@ import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensityDataFetch
 import io.carbonintensity.executionplanner.runtime.impl.ZonedCarbonIntensityPeriod;
 import io.carbonintensity.executionplanner.spi.CarbonIntensityPlanner;
 import io.carbonintensity.executionplanner.spi.ConcurrencySlotTracker;
+import io.carbonintensity.executionplanner.spi.PlannedExecution;
 import io.carbonintensity.executionplanner.strategy.SingleJobStrategy;
 
 /**
@@ -69,7 +71,7 @@ public class SuccessivePlanner implements CarbonIntensityPlanner<SuccessivePlann
     }
 
     @Override
-    public ZonedDateTime getNextExecutionTime(SuccessivePlanningConstraints constraints) {
+    public PlannedExecution getNextExecutionTime(SuccessivePlanningConstraints constraints) {
         ZonedDateTime ws;
         ZonedDateTime we;
 
@@ -94,13 +96,13 @@ public class SuccessivePlanner implements CarbonIntensityPlanner<SuccessivePlann
 
         if (slotTracker == null || maxConcurrentPerSlot <= 0) {
             Timeslot best = strategy.bestTimeslot(ws, we, constraints.getDuration(), carbonIntensity);
-            return best == null ? null : best.start();
+            return best == null ? null : toPlannedExecution(best);
         }
 
         return pickTimeslot(strategy, constraints, ws, we, carbonIntensity);
     }
 
-    private ZonedDateTime pickTimeslot(SingleJobStrategy strategy, SuccessivePlanningConstraints constraints,
+    private PlannedExecution pickTimeslot(SingleJobStrategy strategy, SuccessivePlanningConstraints constraints,
             ZonedDateTime ws, ZonedDateTime we, CarbonIntensity carbonIntensity) {
         List<Timeslot> ranked = strategy.rankedTimeslots(ws, we, constraints.getDuration(), carbonIntensity);
         if (ranked.isEmpty()) {
@@ -111,7 +113,7 @@ public class SuccessivePlanner implements CarbonIntensityPlanner<SuccessivePlann
         String identity = constraints.getIdentity();
         for (Timeslot candidate : ranked) {
             if (slotTracker.tryReserve(zone, identity, candidate.start().toInstant(), maxConcurrentPerSlot)) {
-                return candidate.start();
+                return toPlannedExecution(candidate);
             }
         }
 
@@ -122,7 +124,11 @@ public class SuccessivePlanner implements CarbonIntensityPlanner<SuccessivePlann
                 "Concurrency limit of {} per slot exceeded for zone {} at {} - scheduling '{}' anyway to honor its gap window",
                 maxConcurrentPerSlot, zone, best.start(), identity);
         slotTracker.reserve(zone, identity, best.start().toInstant());
-        return best.start();
+        return toPlannedExecution(best);
+    }
+
+    private static PlannedExecution toPlannedExecution(Timeslot timeslot) {
+        return new PlannedExecution(timeslot.start(), Optional.ofNullable(timeslot.carbonIntensity()));
     }
 
 }

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/spi/CarbonIntensityPlanner.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/spi/CarbonIntensityPlanner.java
@@ -5,7 +5,8 @@ public interface CarbonIntensityPlanner<T extends PlanningConstraints> {
     boolean canSchedule(T constraints);
 
     /**
-     * @return the chosen fire time and its carbon-intensity value, or {@code null} if no timeslot could be found
+     * @return the chosen fire time and its carbon-intensity value, or
+     *         {@code null} if no timeslot could be found
      */
     PlannedExecution getNextExecutionTime(T constraints);
 }

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/spi/CarbonIntensityPlanner.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/spi/CarbonIntensityPlanner.java
@@ -1,10 +1,11 @@
 package io.carbonintensity.executionplanner.spi;
 
-import java.time.ZonedDateTime;
-
 public interface CarbonIntensityPlanner<T extends PlanningConstraints> {
 
     boolean canSchedule(T constraints);
 
-    ZonedDateTime getNextExecutionTime(T constraints);
+    /**
+     * @return the chosen fire time and its carbon-intensity value, or {@code null} if no timeslot could be found
+     */
+    PlannedExecution getNextExecutionTime(T constraints);
 }

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/spi/PlannedExecution.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/spi/PlannedExecution.java
@@ -1,0 +1,22 @@
+package io.carbonintensity.executionplanner.spi;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * The outcome of a successful {@link CarbonIntensityPlanner#getNextExecutionTime} call: the chosen fire time, and
+ * the carbon-intensity value of the timeslot it was chosen from, when known.
+ * <p>
+ * {@link CarbonIntensityPlanner#getNextExecutionTime} itself may still return {@code null} (no timeslot could be
+ * found) - this type only wraps the successful case.
+ */
+public record PlannedExecution(ZonedDateTime fireTime, Optional<BigDecimal> intensityValue) {
+
+    public PlannedExecution {
+        Objects.requireNonNull(fireTime, "FireTime cannot be null");
+        Objects.requireNonNull(intensityValue, "IntensityValue cannot be null - use Optional.empty()");
+    }
+
+}

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/spi/PlannedExecution.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/spi/PlannedExecution.java
@@ -8,11 +8,12 @@ import java.util.Optional;
 import io.carbonintensity.executionplanner.planner.Timeslot;
 
 /**
- * The outcome of a successful {@link CarbonIntensityPlanner#getNextExecutionTime} call: the chosen fire time, and
- * the carbon-intensity value of the timeslot it was chosen from, when known.
+ * The outcome of a successful {@code getNextExecutionTime} call: the
+ * chosen fire time, and the carbon-intensity value of the timeslot it
+ * was chosen from, when known.
  * <p>
- * {@link CarbonIntensityPlanner#getNextExecutionTime} itself may still return {@code null} (no timeslot could be
- * found) - this type only wraps the successful case.
+ * {@link CarbonIntensityPlanner#getNextExecutionTime} may still return
+ * {@code null} (no timeslot found) - this only wraps the success case.
  */
 public record PlannedExecution(ZonedDateTime fireTime, Optional<BigDecimal> intensityValue) {
 
@@ -22,9 +23,11 @@ public record PlannedExecution(ZonedDateTime fireTime, Optional<BigDecimal> inte
     }
 
     /**
-     * The single, shared conversion point every {@link CarbonIntensityPlanner} implementation should use - so a
-     * {@code null} {@link Timeslot#carbonIntensity()} (a genuine data gap) consistently becomes an absent
-     * {@code intensityValue} here, rather than each planner re-deriving that mapping on its own.
+     * The single, shared conversion point every {@link CarbonIntensityPlanner}
+     * implementation should use - so a {@code null}
+     * {@link Timeslot#carbonIntensity()} (a genuine data gap) consistently
+     * becomes an absent {@code intensityValue}, rather than each planner
+     * re-deriving that mapping on its own.
      */
     public static PlannedExecution from(Timeslot timeslot) {
         return new PlannedExecution(timeslot.start(), Optional.ofNullable(timeslot.carbonIntensity()));

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/spi/PlannedExecution.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/spi/PlannedExecution.java
@@ -5,6 +5,8 @@ import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.Optional;
 
+import io.carbonintensity.executionplanner.planner.Timeslot;
+
 /**
  * The outcome of a successful {@link CarbonIntensityPlanner#getNextExecutionTime} call: the chosen fire time, and
  * the carbon-intensity value of the timeslot it was chosen from, when known.
@@ -19,4 +21,12 @@ public record PlannedExecution(ZonedDateTime fireTime, Optional<BigDecimal> inte
         Objects.requireNonNull(intensityValue, "IntensityValue cannot be null - use Optional.empty()");
     }
 
+    /**
+     * The single, shared conversion point every {@link CarbonIntensityPlanner} implementation should use - so a
+     * {@code null} {@link Timeslot#carbonIntensity()} (a genuine data gap) consistently becomes an absent
+     * {@code intensityValue} here, rather than each planner re-deriving that mapping on its own.
+     */
+    public static PlannedExecution from(Timeslot timeslot) {
+        return new PlannedExecution(timeslot.start(), Optional.ofNullable(timeslot.carbonIntensity()));
+    }
 }

--- a/execution-planner/src/main/java/io/carbonintensity/executionplanner/strategy/SingleJobStrategy.java
+++ b/execution-planner/src/main/java/io/carbonintensity/executionplanner/strategy/SingleJobStrategy.java
@@ -54,8 +54,10 @@ public class SingleJobStrategy implements PlanningStrategy {
             CarbonIntensity carbonIntensity) {
         // create timeslots and calculate carbon intensity
         List<Timeslot> timeslots = new ArrayList<>(getTimeslots(ws, we, duration, resolution, carbonIntensity));
-        // stable sort: on equal carbon intensity, the chronologically first slot stays first
-        timeslots.sort(Comparator.comparing(Timeslot::carbonIntensity));
+        // stable sort: on equal carbon intensity, the chronologically first slot stays first. A null
+        // carbonIntensity (a genuine data gap, see Timeslot#carbonIntensity) sorts last - a slot we have no data
+        // for can't be called "green", so it's only ever picked when every other candidate is equally unknown.
+        timeslots.sort(Comparator.comparing(Timeslot::carbonIntensity, Comparator.nullsLast(Comparator.naturalOrder())));
         return timeslots;
     }
 

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/TestTimeslot.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/TestTimeslot.java
@@ -72,4 +72,19 @@ class TestTimeslot {
         // should give exactly one slot
         assertThat(timeslots).hasSize(1);
     }
+
+    @Test
+    void testNoOverlappingDataYieldsAnAbsentIntensityNeverAZero() {
+        // Far outside the fixture's actual date range - no CarbonIntensityPeriod overlaps this window at all,
+        // a genuine data gap that must not be conflated with a real zero-intensity slot.
+        ZonedDateTime ws = ZonedDateTime.parse("2099-01-01T00:00:00Z");
+        ZonedDateTime we = ws.plusHours(1);
+
+        List<CarbonIntensityPeriod> periods = CarbonIntensityPeriod.of(carbonIntensity);
+        assertThat(Timeslot.calculateCarbonIntensity(periods, ws, we)).isEmpty();
+
+        List<Timeslot> timeslots = Timeslot.getTimeslots(ws, we, ofHours(1), ofHours(1), carbonIntensity);
+        assertThat(timeslots).isNotEmpty();
+        assertThat(timeslots).extracting(Timeslot::carbonIntensity).containsOnlyNulls();
+    }
 }

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/fixedwindow/TestFixedWindowPlanner.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/fixedwindow/TestFixedWindowPlanner.java
@@ -28,6 +28,7 @@ import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensityDataFetch
 import io.carbonintensity.executionplanner.runtime.impl.rest.CarbonIntensityJsonParser;
 import io.carbonintensity.executionplanner.spi.CarbonIntensityPlanner;
 import io.carbonintensity.executionplanner.spi.ConcurrencySlotTracker;
+import io.carbonintensity.executionplanner.spi.PlannedExecution;
 
 @ExtendWith(MockitoExtension.class)
 class TestFixedWindowPlanner {
@@ -39,6 +40,10 @@ class TestFixedWindowPlanner {
     public void setup() {
         carbonIntensityDataFetcher = mock(CarbonIntensityDataFetcher.class);
         defaultCarbonIntensityScheduler = new FixedWindowPlanner(carbonIntensityDataFetcher);
+    }
+
+    private static ZonedDateTime fireTime(PlannedExecution execution) {
+        return execution == null ? null : execution.fireTime();
     }
 
     private static FixedWindowPlanningConstraints constraintsFor(String identity, ZonedDateTime start, ZonedDateTime end) {
@@ -88,8 +93,8 @@ class TestFixedWindowPlanner {
         var constraintsA = constraintsFor("job-a", ws, we);
         var constraintsB = constraintsFor("job-b", ws, we);
 
-        ZonedDateTime timeA = plannerA.getNextExecutionTime(constraintsA);
-        ZonedDateTime timeB = plannerB.getNextExecutionTime(constraintsB);
+        ZonedDateTime timeA = fireTime(plannerA.getNextExecutionTime(constraintsA));
+        ZonedDateTime timeB = fireTime(plannerB.getNextExecutionTime(constraintsB));
 
         assertThat(timeA).isNotNull();
         assertThat(timeB).isNotNull();
@@ -114,8 +119,8 @@ class TestFixedWindowPlanner {
         var constraintsA = constraintsFor("job-a", "NL", ws, we);
         var constraintsB = constraintsFor("job-b", "DE", ws, we);
 
-        ZonedDateTime timeA = plannerA.getNextExecutionTime(constraintsA);
-        ZonedDateTime timeB = plannerB.getNextExecutionTime(constraintsB);
+        ZonedDateTime timeA = fireTime(plannerA.getNextExecutionTime(constraintsA));
+        ZonedDateTime timeB = fireTime(plannerB.getNextExecutionTime(constraintsB));
 
         assertThat(timeA).isNotNull();
         assertThat(timeB).isNotNull();
@@ -142,8 +147,8 @@ class TestFixedWindowPlanner {
         CarbonIntensityPlanner<FixedWindowPlanningConstraints> plannerB = new FixedWindowPlanner(sharedFetcher, tracker,
                 maxConcurrentPerSlot);
 
-        ZonedDateTime timeA = plannerA.getNextExecutionTime(constraintsFor("job-a", ws, we));
-        ZonedDateTime timeB = plannerB.getNextExecutionTime(constraintsFor("job-b", ws, we));
+        ZonedDateTime timeA = fireTime(plannerA.getNextExecutionTime(constraintsFor("job-a", ws, we)));
+        ZonedDateTime timeB = fireTime(plannerB.getNextExecutionTime(constraintsFor("job-b", ws, we)));
 
         assertThat(timeA).isNotNull();
         assertThat(timeB).isNotNull();
@@ -185,9 +190,9 @@ class TestFixedWindowPlanner {
         ZonedDateTime we = ws.plusHours(4);
         Duration duration = Duration.ofHours(1);
 
-        ZonedDateTime timeA = plannerA.getNextExecutionTime(constraintsFor("job-a", ws, we, duration));
-        ZonedDateTime timeB = plannerB.getNextExecutionTime(constraintsFor("job-b", ws, we, duration));
-        ZonedDateTime timeC = plannerC.getNextExecutionTime(constraintsFor("job-c", ws, we, duration));
+        ZonedDateTime timeA = fireTime(plannerA.getNextExecutionTime(constraintsFor("job-a", ws, we, duration)));
+        ZonedDateTime timeB = fireTime(plannerB.getNextExecutionTime(constraintsFor("job-b", ws, we, duration)));
+        ZonedDateTime timeC = fireTime(plannerC.getNextExecutionTime(constraintsFor("job-c", ws, we, duration)));
 
         // the three tied (CI 50) slots are claimed in chronological order: 01:00, then 02:00, then 03:00
         assertThat(timeA).isEqualTo(ws.plusHours(1));
@@ -225,7 +230,7 @@ class TestFixedWindowPlanner {
                 .withTimeZoneId(ZoneId.of("UTC"))
                 .build();
 
-        ZonedDateTime nextExecutionTime = defaultCarbonIntensityScheduler.getNextExecutionTime(constraints);
+        ZonedDateTime nextExecutionTime = fireTime(defaultCarbonIntensityScheduler.getNextExecutionTime(constraints));
         assertThat(nextExecutionTime).isNotNull();
         assertThat(nextExecutionTime).isAfter(now.minusMinutes(1));
         assertThat(nextExecutionTime).isBefore(now.plusDays(1));
@@ -261,7 +266,7 @@ class TestFixedWindowPlanner {
                 .withTimeZoneId(ZoneId.of("UTC"))
                 .build();
 
-        ZonedDateTime nextExecutionTime = defaultCarbonIntensityScheduler.getNextExecutionTime(constraints);
+        ZonedDateTime nextExecutionTime = fireTime(defaultCarbonIntensityScheduler.getNextExecutionTime(constraints));
         assertThat(nextExecutionTime).isNotNull();
         assertThat(nextExecutionTime.getDayOfWeek()).isEqualTo(DayOfWeek.MONDAY);
         assertThat(nextExecutionTime).isAfter(now.minusMinutes(1));
@@ -298,7 +303,7 @@ class TestFixedWindowPlanner {
                 .withTimeZoneId(ZoneId.of("UTC"))
                 .build();
 
-        ZonedDateTime nextExecutionTime = defaultCarbonIntensityScheduler.getNextExecutionTime(constraints);
+        ZonedDateTime nextExecutionTime = fireTime(defaultCarbonIntensityScheduler.getNextExecutionTime(constraints));
         assertThat(nextExecutionTime).isNotNull();
         assertThat(nextExecutionTime.getDayOfMonth()).isEqualTo(1);
         assertThat(nextExecutionTime).isAfter(now.minusMinutes(1));
@@ -335,7 +340,7 @@ class TestFixedWindowPlanner {
                 .withTimeZoneId(ZoneId.of("UTC"))
                 .build();
 
-        ZonedDateTime nextExecutionTime = defaultCarbonIntensityScheduler.getNextExecutionTime(constraints);
+        ZonedDateTime nextExecutionTime = fireTime(defaultCarbonIntensityScheduler.getNextExecutionTime(constraints));
         assertThat(nextExecutionTime).isNotNull();
         assertThat(nextExecutionTime.getDayOfWeek()).isNotEqualTo(DayOfWeek.SUNDAY);
         assertThat(nextExecutionTime).isAfter(date.minusMinutes(1));

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/successive/TestSuccessivePlanner.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/planner/successive/TestSuccessivePlanner.java
@@ -17,6 +17,7 @@ import io.carbonintensity.executionplanner.runtime.impl.CarbonIntensityDataFetch
 import io.carbonintensity.executionplanner.runtime.impl.rest.CarbonIntensityJsonParser;
 import io.carbonintensity.executionplanner.spi.CarbonIntensityPlanner;
 import io.carbonintensity.executionplanner.spi.ConcurrencySlotTracker;
+import io.carbonintensity.executionplanner.spi.PlannedExecution;
 
 @ExtendWith(MockitoExtension.class)
 class TestSuccessivePlanner {
@@ -28,6 +29,10 @@ class TestSuccessivePlanner {
     public void setup() {
         carbonIntensityDataFetcher = mock(CarbonIntensityDataFetcher.class);
         defaultCarbonIntensityScheduler = new SuccessivePlanner(carbonIntensityDataFetcher);
+    }
+
+    private static ZonedDateTime fireTime(PlannedExecution execution) {
+        return execution == null ? null : execution.fireTime();
     }
 
     private static SuccessivePlanningConstraints constraintsFor(String identity, ZonedDateTime lastExecutionTime,
@@ -62,7 +67,7 @@ class TestSuccessivePlanner {
                 .withCarbonIntensityZone("NL")
                 .build();
 
-        ZonedDateTime nextExecutionTime = defaultCarbonIntensityScheduler.getNextExecutionTime(constraints);
+        ZonedDateTime nextExecutionTime = fireTime(defaultCarbonIntensityScheduler.getNextExecutionTime(constraints));
 
         assertThat(nextExecutionTime).isNotNull();
         assertThat(nextExecutionTime.isBefore(now.plus(initialWarmup))).isTrue();
@@ -90,7 +95,7 @@ class TestSuccessivePlanner {
                 .withCarbonIntensityZone("NL")
                 .build();
 
-        ZonedDateTime nextExecutionTime = defaultCarbonIntensityScheduler.getNextExecutionTime(constraints);
+        ZonedDateTime nextExecutionTime = fireTime(defaultCarbonIntensityScheduler.getNextExecutionTime(constraints));
         assertThat(nextExecutionTime).isNotNull();
 
         // note: we allow the execution on the exact minGap, so should not be before (but equal or after)
@@ -113,8 +118,10 @@ class TestSuccessivePlanner {
         Duration minGap = Duration.ZERO;
         Duration maxGap = Duration.ofHours(6);
 
-        ZonedDateTime timeA = plannerA.getNextExecutionTime(constraintsFor("job-a", lastExecutionTime, minGap, maxGap));
-        ZonedDateTime timeB = plannerB.getNextExecutionTime(constraintsFor("job-b", lastExecutionTime, minGap, maxGap));
+        ZonedDateTime timeA = fireTime(
+                plannerA.getNextExecutionTime(constraintsFor("job-a", lastExecutionTime, minGap, maxGap)));
+        ZonedDateTime timeB = fireTime(
+                plannerB.getNextExecutionTime(constraintsFor("job-b", lastExecutionTime, minGap, maxGap)));
 
         assertThat(timeA).isNotNull();
         assertThat(timeB).isNotNull();
@@ -153,8 +160,10 @@ class TestSuccessivePlanner {
         CarbonIntensityPlanner<SuccessivePlanningConstraints> plannerB = new SuccessivePlanner(sharedFetcher, tracker,
                 maxConcurrentPerSlot);
 
-        ZonedDateTime timeA = plannerA.getNextExecutionTime(constraintsFor("job-a", lastExecutionTime, minGap, maxGap));
-        ZonedDateTime timeB = plannerB.getNextExecutionTime(constraintsFor("job-b", lastExecutionTime, minGap, maxGap));
+        ZonedDateTime timeA = fireTime(
+                plannerA.getNextExecutionTime(constraintsFor("job-a", lastExecutionTime, minGap, maxGap)));
+        ZonedDateTime timeB = fireTime(
+                plannerB.getNextExecutionTime(constraintsFor("job-b", lastExecutionTime, minGap, maxGap)));
 
         assertThat(timeA).isNotNull();
         assertThat(timeB).isNotNull();

--- a/execution-planner/src/test/java/io/carbonintensity/executionplanner/strategy/TestSingleJobStrategy.java
+++ b/execution-planner/src/test/java/io/carbonintensity/executionplanner/strategy/TestSingleJobStrategy.java
@@ -93,6 +93,32 @@ class TestSingleJobStrategy {
         );
     }
 
+    @Test
+    void testRankedTimeslotsSortsGenuineDataGapsLast() {
+        // a single 30-minute data point at 00:00 - candidates starting at 01:00 and 02:00 have no overlapping
+        // data at all, a genuine gap that must not be conflated with a real zero-intensity slot
+        CarbonIntensity carbonIntensity = new CarbonIntensity();
+        carbonIntensity.setZone("NL");
+        carbonIntensity.setResolution(Duration.ofMinutes(30));
+        carbonIntensity.setStart(Instant.parse("2024-01-01T00:00:00Z"));
+        carbonIntensity.setEnd(Instant.parse("2024-01-01T00:30:00Z"));
+        carbonIntensity.setData(List.of(new BigDecimal("50")));
+
+        ZonedDateTime ws = ZonedDateTime.parse("2024-01-01T00:00:00Z");
+        ZonedDateTime we = ws.plusHours(2);
+        Duration d = Duration.ofHours(1);
+
+        SingleJobStrategy strategy = new SingleJobStrategy(Duration.ofHours(1));
+        List<Timeslot> ranked = strategy.rankedTimeslots(ws, we, d, carbonIntensity);
+
+        assertThat(ranked).hasSize(3);
+        // the one slot overlapping actual data sorts first; the two with no overlapping data at all sort last,
+        // rather than throwing a NullPointerException or being indistinguishable from a real zero
+        assertThat(ranked.get(0).carbonIntensity()).isNotNull();
+        assertThat(ranked.get(1).carbonIntensity()).isNull();
+        assertThat(ranked.get(2).carbonIntensity()).isNull();
+    }
+
     private CarbonIntensity loadCarbonIntensityFromFile(String fileName) {
         return ciParser.parse(ClassLoader.getSystemResourceAsStream(fileName));
     }


### PR DESCRIPTION
## Summary

Adds a per-job "decision timeline": an unconditional, retained record of when each job actually fired, why, and at what carbon-intensity value (when known) - answering "why was this job shifted" without opting in to anything.

- Introduces `DecisionStrategy` (`FIXED_WINDOW`/`SUCCESSIVE`) and `DecisionReason` (a greenest-available-slot outcome, plus two fallback reasons) to classify how and why a job fired.
- Every `@GreenScheduled` or programmatic job now records this automatically, independent of the separate (opt-in) carbon-impact feature.
- The recorded history is queryable, and also published as an event so it can be exported or persisted beyond the default in-memory store.
- The scheduler's "job fired" logging is now consistent and enabled at a sensible level across all trigger types (closes #117), with the job's identity/strategy/zone attached to every log line for the duration of its execution.
- The carbon-intensity value the scheduler already computes when picking a green execution slot is no longer discarded.

Quarkus/Spring/Micronaut extension support and the public docs page are intentionally out of scope here and blocked on this PR merging first.

Note: this branch is based on a clean `main`, not on the still-open #280 - the two touch overlapping files but are independent; a merge conflict between them is expected and should be resolved at merge time by whichever lands second.

## Documentation

The public docs page for this feature (tracked separately) leads with how to quickly check "is my job actually running" via logging, before explaining the timeline itself, how it relates to the separate carbon-impact feature, and how to plug in a custom store.

## Test plan

- [x] `./mvnw -pl core test` and `./mvnw -pl execution-planner test` - all green
- [x] `./mvnw -DskipTests install` - full multi-module build compiles cleanly against the changed planner contract