### PR TITLE
Link Supported zones README section to the live docs and cloud-region lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,11 @@ public void greenSuccessiveWindowJob() {
 Visit the [carbonintensity.io](https://carbonintensity.io) homepage to get an API key for the scheduler.
 
 ### Supported zones
-The current supported list can be found soon on [carbonintensity.io](https://carbonintensity.io).
+The current supported list can be found on the [Supported Zones](https://carbonintensity.io/supported-zones) page.
+
+Running on AWS, Azure or GCP and not sure which `carbonIntensityZone` your region maps to? See
+[EU Cloud Region Mapping](https://carbonintensity.io/cloud-region-mapping) to look it up from
+your cloud provider's region code.
 
 ### Concurrent executions
 The scheduler may start a process multiple times when multiple instances of the same application are running 


### PR DESCRIPTION
## Summary
- The "Supported zones" section still said "can be found soon" - stale, the page has existed on carbonintensity.io for a while.
- Added a pointer to the new EU Cloud Region Mapping lookup on carbonintensity.io, so AWS/Azure/GCP users (the typical audience for both) can find it from the README instead of only by browsing the docs site's sidebar.

## Test plan
- [x] Docs-only change, no code affected.