### PR TITLE
Auto-approve routine dependabot bumps, not just auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,6 +12,11 @@ name: Dependabot auto-merge
 # (Settings > General > Pull Requests) - that's an admin-only toggle this workflow can't set
 # itself. Until then, `gh pr merge --auto` below will fail harmlessly and the PR just waits for a
 # manual merge like before.
+#
+# Auto-merge alone wasn't enough: branch protection requires an approving review before anything
+# merges, and nobody was approving these, so the backlog just moved from "unmerged" to "enabled,
+# still blocked". The approval step below covers that for the same routine set - a human still
+# has the final say on anything framework-related.
 
 on:
   pull_request:
@@ -35,6 +40,18 @@ jobs:
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve routine bumps
+        if: |
+          steps.metadata.outputs.update-type != 'version-update:semver-major' &&
+          !contains(steps.metadata.outputs.dependency-names, 'quarkus') &&
+          !contains(steps.metadata.outputs.dependency-names, 'spring.boot') &&
+          !contains(steps.metadata.outputs.dependency-names, 'spring-boot') &&
+          !contains(steps.metadata.outputs.dependency-names, 'micronaut')
+        run: gh pr review --approve "$PR_URL" --body "Auto-approved - routine dependency bump, not one of the excluded frameworks."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge for routine bumps
         if: |


### PR DESCRIPTION
## Summary

The existing dependabot-auto-merge.yml enables auto-merge for routine bumps, but that alone doesn't clear the backlog: branch protection requires an approving review before anything merges, and nobody's been approving these. Result: 6 open PRs currently sit with auto-merge armed but blocked (`REVIEW_REQUIRED`) despite green CI - the queue just moved from "unmerged" to "enabled, still blocked".

Adds an "Approve routine bumps" step ahead of the existing auto-merge step, using the identical condition (excludes semver-major bumps, and anything touching Quarkus/Spring Boot/Micronaut - those three still need an explicit human review and manual merge, unchanged).

## Verification

Workflow-only change (`.github/workflows/**` is in this repo's build.yml `paths-ignore`, so no build/test impact). Validated YAML syntax locally.