### PR TITLE
Fix a permanently-stuck fixed-window trigger and stale overdue reporting

### DIFF
--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/SimpleScheduler.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/SimpleScheduler.java
@@ -555,9 +555,11 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         }
 
         /**
-         * Folds lastFireTime into the query, like evaluate does. Without
-         * it, this kept reporting the first-ever slot as permanently
-         * overdue, no matter how many times the job had fired since.
+         * Folds lastFireTime into the query, like evaluate does - without it,
+         * next-fire queries kept reporting the first-ever slot as permanently
+         * overdue, no matter how many times the job fired.
+         *
+         * @return constraints reflecting the most recent fire, or the original ones
          */
         private SuccessivePlanningConstraints effectiveConstraints() {
             return lastFireTime == null

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/SimpleScheduler.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/SimpleScheduler.java
@@ -157,10 +157,10 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
             if (id.isEmpty()) {
                 id = nameSequence + "_" + method.getMethodDescription();
             }
-            final var constraints = GreenScheduledAnnotationParser.createConstraints(id, scheduled, clock);
-            SimpleTrigger trigger = createTrigger(id, method.getMethodDescription(),
-                    GreenScheduledAnnotationParser.parseOverdueGracePeriod(scheduled, schedulerConfig.getOverdueGracePeriod()),
-                    constraints);
+            Duration overdueGracePeriod = GreenScheduledAnnotationParser.parseOverdueGracePeriod(scheduled,
+                    schedulerConfig.getOverdueGracePeriod());
+            final var constraints = GreenScheduledAnnotationParser.createConstraints(id, scheduled, clock, overdueGracePeriod);
+            SimpleTrigger trigger = createTrigger(id, method.getMethodDescription(), overdueGracePeriod, constraints);
             ScheduledInvoker invoker = initInvoker(method.getInvoker(), events,
                     scheduled.concurrentExecution(), initSkipPredicate(scheduled.skipExecutionIf()), jobInstrumenter);
             registerTask(trigger.id, new ScheduledTask(trigger, invoker, false));
@@ -548,10 +548,21 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
         @Override
         public Instant getNextFireTime() {
             if (successivePlanner.canSchedule(constraints)) {
-                return successivePlanner.getNextExecutionTime(constraints).toInstant();
+                return successivePlanner.getNextExecutionTime(effectiveConstraints()).toInstant();
             }
             // fallback to interval trigger
             return super.getNextFireTime();
+        }
+
+        /**
+         * Folds lastFireTime into the query, like evaluate does. Without
+         * it, this kept reporting the first-ever slot as permanently
+         * overdue, no matter how many times the job had fired since.
+         */
+        private SuccessivePlanningConstraints effectiveConstraints() {
+            return lastFireTime == null
+                    ? constraints
+                    : DefaultSuccessivePlanningConstraints.from(constraints).withLastExecutionTime(lastFireTime).build();
         }
 
         @Override
@@ -570,10 +581,7 @@ public class SimpleScheduler implements Scheduler, AutoCloseable {
 
                 // sequential invocations
                 if (lastFireTime != null && now.plusSeconds(1).isAfter(lastFireTime.plus(constraints.getMinimumGap()))) {
-                    nextExecutionTime = successivePlanner
-                            .getNextExecutionTime(DefaultSuccessivePlanningConstraints.from(constraints)
-                                    .withLastExecutionTime(lastFireTime)
-                                    .build());
+                    nextExecutionTime = successivePlanner.getNextExecutionTime(effectiveConstraints());
                 }
 
                 if (nextExecutionTime != null) {

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/impl/annotation/FixedWindowExpressionParser.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/impl/annotation/FixedWindowExpressionParser.java
@@ -1,6 +1,7 @@
 package io.carbonintensity.scheduler.runtime.impl.annotation;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -22,7 +23,8 @@ public class FixedWindowExpressionParser {
     private FixedWindowExpressionParser() {
     }
 
-    public static Optional<FixedWindowConstraints> parse(String expression, Clock clock, ZoneId timeZoneId) {
+    public static Optional<FixedWindowConstraints> parse(String expression, Clock clock, ZoneId timeZoneId,
+            Duration overdueGracePeriod) {
         if (expression == null || expression.isEmpty()) {
             return Optional.empty();
         }
@@ -36,8 +38,9 @@ public class FixedWindowExpressionParser {
                 LocalTime endTime = parseTime(parts[1]);
 
                 ZonedDateTime zonedStartTime = getZonedStartDateTimeForNextExecutionWindow(clock, timeZoneId, startTime,
-                        endTime);
-                ZonedDateTime zonedEndTime = getZonedEndDateTimeForNextExecutionWindow(clock, timeZoneId, startTime, endTime);
+                        endTime, overdueGracePeriod);
+                ZonedDateTime zonedEndTime = getZonedEndDateTimeForNextExecutionWindow(clock, timeZoneId, startTime, endTime,
+                        overdueGracePeriod);
 
                 return Optional.of(new FixedWindowConstraints(zonedStartTime, zonedEndTime));
             } catch (DateTimeParseException e) {
@@ -54,15 +57,33 @@ public class FixedWindowExpressionParser {
     }
 
     public static ZonedDateTime getZonedStartDateTimeForNextExecutionWindow(Clock clock, ZoneId timeZoneId, LocalTime startTime,
-            LocalTime endTime) {
+            LocalTime endTime, Duration overdueGracePeriod) {
         Clock clockForTimeZoneId = clock.withZone(timeZoneId);
         LocalDate localDateForStartTime = LocalDate.now(clockForTimeZoneId);
         boolean nowIsNextDayBeforeEndWindow = isOvernightWindow(startTime, endTime)
                 && isWithinLastNightWindow(clockForTimeZoneId, startTime, endTime);
         if (nowIsNextDayBeforeEndWindow) {
             localDateForStartTime = localDateForStartTime.minusDays(1);
+        } else if (todaysWindowHasAlreadyEnded(clockForTimeZoneId, startTime, endTime, overdueGracePeriod)) {
+            localDateForStartTime = localDateForStartTime.plusDays(1);
         }
         return resolveWindowStart(localDateForStartTime, startTime, timeZoneId);
+    }
+
+    /**
+     * A same-day window whose end time (plus its grace period - a job invoked just after the window closed, but
+     * still inside the grace period, is still using today's window) is already behind "now" needs the next
+     * occurrence to be tomorrow's, not today's already-closed one - only relevant for a non-overnight window,
+     * since an overnight one is already handled by {@link #isWithinLastNightWindow}.
+     */
+    private static boolean todaysWindowHasAlreadyEnded(Clock clockForTimeZoneId, LocalTime startTime, LocalTime endTime,
+            Duration overdueGracePeriod) {
+        if (isOvernightWindow(startTime, endTime)) {
+            return false;
+        }
+        ZonedDateTime todaysEndPlusGrace = ZonedDateTime.of(LocalDate.now(clockForTimeZoneId), endTime,
+                clockForTimeZoneId.getZone()).plus(overdueGracePeriod);
+        return !ZonedDateTime.now(clockForTimeZoneId).isBefore(todaysEndPlusGrace);
     }
 
     /**
@@ -85,12 +106,12 @@ public class FixedWindowExpressionParser {
     }
 
     public static ZonedDateTime getZonedEndDateTimeForNextExecutionWindow(Clock clock, ZoneId timeZoneId, LocalTime startTime,
-            LocalTime endTime) {
+            LocalTime endTime, Duration overdueGracePeriod) {
         Clock clockForTimeZoneId = clock.withZone(timeZoneId);
         LocalDate localDateForEndTime = LocalDate.now(clockForTimeZoneId);
         boolean endIsNextDay = isOvernightWindow(startTime, endTime)
                 && !isWithinLastNightWindow(clockForTimeZoneId, startTime, endTime);
-        if (endIsNextDay) {
+        if (endIsNextDay || todaysWindowHasAlreadyEnded(clockForTimeZoneId, startTime, endTime, overdueGracePeriod)) {
             localDateForEndTime = localDateForEndTime.plusDays(1);
         }
         return ZonedDateTime.of(localDateForEndTime, endTime, timeZoneId);

--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/impl/annotation/GreenScheduledAnnotationParser.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/impl/annotation/GreenScheduledAnnotationParser.java
@@ -77,7 +77,8 @@ public class GreenScheduledAnnotationParser {
         }
     }
 
-    public static PlanningConstraints createConstraints(String identity, GreenScheduled annotation, Clock clock) {
+    public static PlanningConstraints createConstraints(String identity, GreenScheduled annotation, Clock clock,
+            Duration overdueGracePeriod) {
         List<String> validationErrors = GreenScheduledAnnotationValidation.validateAndReturnValidationErrors(annotation);
         if (!validationErrors.isEmpty()) {
             throw new IllegalArgumentException(
@@ -91,7 +92,8 @@ public class GreenScheduledAnnotationParser {
                 .map(ZoneId::of)
                 .orElse(ZoneId.systemDefault());
 
-        final var optionalFixedWindow = FixedWindowExpressionParser.parse(annotation.fixedWindow(), clock, timeZoneId);
+        final var optionalFixedWindow = FixedWindowExpressionParser.parse(annotation.fixedWindow(), clock, timeZoneId,
+                overdueGracePeriod);
         if (optionalFixedWindow.isPresent()) {
             final var fixedWindow = optionalFixedWindow.get();
 

--- a/core/src/test/java/io/carbonintensity/scheduler/TestSuccessiveWindowScheduler.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/TestSuccessiveWindowScheduler.java
@@ -130,6 +130,62 @@ class TestSuccessiveWindowScheduler {
     }
 
     @Test
+    void getNextFireTimeAndIsOverdueReflectTheMostRecentFireNotJustTheFirstEverSlot() throws InterruptedException {
+        CountDownLatch cdl = new CountDownLatch(1);
+
+        ScheduledInvoker scheduledCountDownInvoker = execution -> {
+            cdl.countDown();
+            return CompletableFuture.completedStage(null);
+        };
+
+        GreenScheduled greenScheduled = AnnotationUtil.newGreenScheduled()
+                .successive("12h 4h 12h")
+                .carbonIntensityZone("NL")
+                .duration("1h")
+                .identity("test")
+                .overdueGracePeriod("PT90S")
+                .timeZone("Europe/Amsterdam")
+                .build();
+
+        ImmutableScheduledMethod immutableScheduledMethod = new ImmutableScheduledMethod(
+                scheduledCountDownInvoker,
+                this.getClass().getName(),
+                "getNextFireTimeAndIsOverdueReflectTheMostRecentFireNotJustTheFirstEverSlot",
+                List.of(greenScheduled));
+
+        MutableClock mutableClock = new MutableClock(
+                Clock.fixed(ZonedDateTime
+                        .of(LocalDateTime.of(LocalDate.of(2024, 6, 1),
+                                LocalTime.of(7, 16)), ZoneId.of("Europe/Amsterdam"))
+                        .toInstant(),
+                        ZoneId.of("UTC")));
+
+        schedulerConfig.setClock(mutableClock);
+        scheduler = new SimpleScheduler(schedulerConfig);
+        scheduler.scheduleMethod(immutableScheduledMethod);
+        mutableClock.getNotifier().register(scheduler);
+        scheduler.start();
+
+        // the greenest slot is at 18:16 - fire it, then jump 20 hours past that (well past the 4-12h gap window,
+        // long enough that the *original, never-advanced* slot would look hours overdue if getNextFireTime()
+        // wrongly kept reporting it instead of the trigger's real, gap-based next slot)
+        mutableClock.shift(Duration.ofHours(11));
+        mutableClock.shift(Duration.ofHours(1));
+        mutableClock.shift(Duration.ofSeconds(1));
+        Awaitility.waitAtMost(SCHEDULER_WAITING_PERIOD, TimeUnit.MILLISECONDS).until(() -> cdl.getCount() == 0);
+
+        mutableClock.shift(Duration.ofHours(20));
+        Trigger trigger = scheduler.getScheduledJob("test");
+
+        Assertions.assertThat(trigger.isOverdue())
+                .as("must not be permanently overdue just because the very first computed slot is long past")
+                .isFalse();
+        Assertions.assertThat(trigger.getNextFireTime())
+                .as("must advance past the last actual fire, not keep reporting the original first-ever slot")
+                .isAfter(trigger.getPreviousFireTime());
+    }
+
+    @Test
     void testSuccessiveWindowScheduler_useCalculatedFallbackInterval() throws InterruptedException {
         CountDownLatch cdl = new CountDownLatch(2);
 

--- a/core/src/test/java/io/carbonintensity/scheduler/runtime/impl/annotation/GreenScheduledAnnotationParserTest.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/runtime/impl/annotation/GreenScheduledAnnotationParserTest.java
@@ -28,7 +28,7 @@ class GreenScheduledAnnotationParserTest {
                 .build();
 
         PlanningConstraints constraints = GreenScheduledAnnotationParser.createConstraints("testJob", annotation,
-                Clock.systemDefaultZone());
+                Clock.systemDefaultZone(), Duration.ZERO);
 
         assertThat(constraints).isInstanceOf(DefaultFixedWindowPlanningConstraints.class);
         DefaultFixedWindowPlanningConstraints fixedConstraints = (DefaultFixedWindowPlanningConstraints) constraints;
@@ -47,7 +47,8 @@ class GreenScheduledAnnotationParserTest {
         Clock clock = Clock.fixed(now.toInstant(),
                 ZoneId.of("UTC"));
 
-        PlanningConstraints constraints = GreenScheduledAnnotationParser.createConstraints("testJob", annotation, clock);
+        PlanningConstraints constraints = GreenScheduledAnnotationParser.createConstraints("testJob", annotation, clock,
+                Duration.ZERO);
 
         assertThat(constraints).isInstanceOf(DefaultSuccessivePlanningConstraints.class);
         DefaultSuccessivePlanningConstraints successiveConstraints = (DefaultSuccessivePlanningConstraints) constraints;
@@ -65,7 +66,7 @@ class GreenScheduledAnnotationParserTest {
                 .carbonIntensityZone("NL")
                 .build();
 
-        assertThatThrownBy(() -> GreenScheduledAnnotationParser.createConstraints("testJob", annotation, null))
+        assertThatThrownBy(() -> GreenScheduledAnnotationParser.createConstraints("testJob", annotation, null, Duration.ZERO))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Found 1 validation error while creating GreenScheduled constraints for testJob: \n" +
                         "Duration must be specified when fixedWindow is specified");

--- a/core/src/test/java/io/carbonintensity/scheduler/runtime/impl/annotation/TestFixedWindowExpressionParser.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/runtime/impl/annotation/TestFixedWindowExpressionParser.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
@@ -22,21 +23,20 @@ class TestFixedWindowExpressionParser {
 
     @Test
     void nullExpressionYieldsEmpty() {
-        assertThat(
-                FixedWindowExpressionParser.parse(null, fixedClockAt(LocalDate.of(2025, 6, 1), LocalTime.of(4, 0)), AMSTERDAM))
-                .isEmpty();
+        assertThat(FixedWindowExpressionParser.parse(null, fixedClockAt(LocalDate.of(2025, 6, 1), LocalTime.of(4, 0)),
+                AMSTERDAM, Duration.ZERO)).isEmpty();
     }
 
     @Test
     void emptyExpressionYieldsEmpty() {
-        assertThat(FixedWindowExpressionParser.parse("", fixedClockAt(LocalDate.of(2025, 6, 1), LocalTime.of(4, 0)), AMSTERDAM))
-                .isEmpty();
+        assertThat(FixedWindowExpressionParser.parse("", fixedClockAt(LocalDate.of(2025, 6, 1), LocalTime.of(4, 0)), AMSTERDAM,
+                Duration.ZERO)).isEmpty();
     }
 
     @Test
     void malformedExpressionThrows() {
         Clock clock = fixedClockAt(LocalDate.of(2025, 6, 1), LocalTime.of(4, 0));
-        assertThatThrownBy(() -> FixedWindowExpressionParser.parse("09:30-11:45", clock, AMSTERDAM))
+        assertThatThrownBy(() -> FixedWindowExpressionParser.parse("09:30-11:45", clock, AMSTERDAM, Duration.ZERO))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Invalid fixedWindow format");
     }
@@ -44,7 +44,7 @@ class TestFixedWindowExpressionParser {
     @Test
     void unparsableTimeThrows() {
         Clock clock = fixedClockAt(LocalDate.of(2025, 6, 1), LocalTime.of(4, 0));
-        assertThatThrownBy(() -> FixedWindowExpressionParser.parse("09:30 not-a-time", clock, AMSTERDAM))
+        assertThatThrownBy(() -> FixedWindowExpressionParser.parse("09:30 not-a-time", clock, AMSTERDAM, Duration.ZERO))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Invalid time format");
     }
@@ -53,7 +53,40 @@ class TestFixedWindowExpressionParser {
     void nonOvernightWindowStartsAndEndsOnTheSameDay() {
         Clock clock = fixedClockAt(LocalDate.of(2025, 6, 1), LocalTime.of(4, 0));
 
-        Optional<FixedWindowConstraints> constraints = FixedWindowExpressionParser.parse("09:30 11:45", clock, AMSTERDAM);
+        Optional<FixedWindowConstraints> constraints = FixedWindowExpressionParser.parse("09:30 11:45", clock, AMSTERDAM,
+                Duration.ZERO);
+
+        assertThat(constraints).isPresent();
+        assertThat(constraints.get().getStartTime())
+                .isEqualTo(ZonedDateTime.of(LocalDate.of(2025, 6, 1), LocalTime.of(9, 30), AMSTERDAM));
+        assertThat(constraints.get().getEndTime())
+                .isEqualTo(ZonedDateTime.of(LocalDate.of(2025, 6, 1), LocalTime.of(11, 45), AMSTERDAM));
+    }
+
+    @Test
+    void nonOvernightWindowRollsToTomorrowWhenTodaysHasAlreadyEnded() {
+        // "now" is 23:09, well after today's 09:30-11:45 window (plus its zero grace period) closed, so the next
+        // occurrence is tomorrow's.
+        Clock clock = fixedClockAt(LocalDate.of(2025, 6, 1), LocalTime.of(23, 9));
+
+        Optional<FixedWindowConstraints> constraints = FixedWindowExpressionParser.parse("09:30 11:45", clock, AMSTERDAM,
+                Duration.ZERO);
+
+        assertThat(constraints).isPresent();
+        assertThat(constraints.get().getStartTime())
+                .isEqualTo(ZonedDateTime.of(LocalDate.of(2025, 6, 2), LocalTime.of(9, 30), AMSTERDAM));
+        assertThat(constraints.get().getEndTime())
+                .isEqualTo(ZonedDateTime.of(LocalDate.of(2025, 6, 2), LocalTime.of(11, 45), AMSTERDAM));
+    }
+
+    @Test
+    void nonOvernightWindowStaysOnTodayWhileStillWithinItsGracePeriod() {
+        // "now" is 30s after today's 09:30-11:45 window closed, but a 90s grace period is still running - the
+        // job hasn't missed its chance yet, so this must still resolve to today's window, not tomorrow's.
+        Clock clock = fixedClockAt(LocalDate.of(2025, 6, 1), LocalTime.of(11, 45, 30));
+
+        Optional<FixedWindowConstraints> constraints = FixedWindowExpressionParser.parse("09:30 11:45", clock, AMSTERDAM,
+                Duration.ofSeconds(90));
 
         assertThat(constraints).isPresent();
         assertThat(constraints.get().getStartTime())
@@ -67,7 +100,8 @@ class TestFixedWindowExpressionParser {
         // "now" is 22:00, before tonight's 23:15 start, so the upcoming window starts today and ends tomorrow.
         Clock clock = fixedClockAt(LocalDate.of(2025, 6, 1), LocalTime.of(22, 0));
 
-        Optional<FixedWindowConstraints> constraints = FixedWindowExpressionParser.parse("23:15 02:15", clock, AMSTERDAM);
+        Optional<FixedWindowConstraints> constraints = FixedWindowExpressionParser.parse("23:15 02:15", clock, AMSTERDAM,
+                Duration.ZERO);
 
         assertThat(constraints).isPresent();
         assertThat(constraints.get().getStartTime())
@@ -81,7 +115,8 @@ class TestFixedWindowExpressionParser {
         // "now" is 01:00, still within last night's window, so it started yesterday and ends today.
         Clock clock = fixedClockAt(LocalDate.of(2025, 6, 2), LocalTime.of(1, 0));
 
-        Optional<FixedWindowConstraints> constraints = FixedWindowExpressionParser.parse("23:15 02:15", clock, AMSTERDAM);
+        Optional<FixedWindowConstraints> constraints = FixedWindowExpressionParser.parse("23:15 02:15", clock, AMSTERDAM,
+                Duration.ZERO);
 
         assertThat(constraints).isPresent();
         assertThat(constraints.get().getStartTime())

--- a/core/src/test/java/io/carbonintensity/scheduler/runtime/impl/annotation/TestFixedWindowExpressionParserProperties.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/runtime/impl/annotation/TestFixedWindowExpressionParserProperties.java
@@ -3,6 +3,7 @@ package io.carbonintensity.scheduler.runtime.impl.annotation;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -80,9 +81,9 @@ class TestFixedWindowExpressionParserProperties {
                     Clock clock = Clock.fixed(ZonedDateTime.of(now, AMSTERDAM).toInstant(), AMSTERDAM);
 
                     ZonedDateTime start = FixedWindowExpressionParser.getZonedStartDateTimeForNextExecutionWindow(clock,
-                            AMSTERDAM, startTime, endTime);
+                            AMSTERDAM, startTime, endTime, Duration.ZERO);
                     ZonedDateTime end = FixedWindowExpressionParser.getZonedEndDateTimeForNextExecutionWindow(clock,
-                            AMSTERDAM, startTime, endTime);
+                            AMSTERDAM, startTime, endTime, Duration.ZERO);
 
                     return start.isBefore(end);
                 })
@@ -117,9 +118,9 @@ class TestFixedWindowExpressionParserProperties {
         Clock clock = Clock.fixed(ZonedDateTime.of(now, nowTime, AMSTERDAM).toInstant(), AMSTERDAM);
 
         ZonedDateTime start = FixedWindowExpressionParser.getZonedStartDateTimeForNextExecutionWindow(clock, AMSTERDAM,
-                startTime, endTime);
+                startTime, endTime, Duration.ZERO);
         ZonedDateTime end = FixedWindowExpressionParser.getZonedEndDateTimeForNextExecutionWindow(clock, AMSTERDAM,
-                startTime, endTime);
+                startTime, endTime, Duration.ZERO);
 
         assertThat(start).isBefore(end);
     }


### PR DESCRIPTION
## Summary

- A fixed-window trigger constructed after its window had already closed for the day never rolled forward to the next occurrence - it stayed permanently stuck, never firing again. The parser only handled rolling an overnight window; a same-day window whose end had already passed was left untouched. It now advances to tomorrow's window, while still honoring an in-progress grace period.
- A successive trigger's next-fire-time (and therefore its overdue status) kept reflecting the very first slot it ever computed instead of the trigger's actual, advancing schedule - so a healthy, on-time job eventually reported permanently overdue. Fixed by folding the trigger's last fire time into the query the same way normal evaluation already does.

Both were found by running a set of fixed-window and successive jobs against real data for an extended period rather than only in short-lived tests.

## Documentation

Not user-facing behavior changes beyond the bug fixes themselves - no documentation update needed.